### PR TITLE
add with_raw_response support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "openai>=1.66.0",
+    "openai>=2.0.0,<3",
     "httpx>=0.25.0",
     "loguru>=0.7.0",
 ]

--- a/src/autobatcher/client.py
+++ b/src/autobatcher/client.py
@@ -51,6 +51,70 @@ class _PendingRequest(Generic[V]):
     future: asyncio.Future[V]
 
 
+class _RawResponseWrapper(Generic[V]):
+    """Stand-in for the openai SDK's ``LegacyAPIResponse`` for batch results.
+
+    The openai SDK exposes ``client.chat.completions.with_raw_response.create(...)``
+    which returns a wrapper object whose ``.parse()`` method yields the parsed
+    body and whose ``.headers`` / ``.http_response`` expose the underlying HTTP
+    metadata. Consumers like ``langchain-openai`` use this surface
+    unconditionally on their non-streaming async path:
+
+    .. code-block:: python
+
+        raw_response = await self.async_client.with_raw_response.create(**payload)
+        response = raw_response.parse()
+
+    Batch results don't have meaningful per-request HTTP metadata (everything
+    comes back through the batch poll), so ``.headers`` is an empty dict and
+    ``.http_response`` is ``None``. The ``.parse()`` method returns the parsed
+    result that the underlying ``.create()`` already produced.
+    """
+
+    def __init__(self, parsed: V) -> None:
+        self._parsed = parsed
+        self.headers: dict[str, str] = {}
+        self.http_response: Any = None
+
+    def parse(self) -> V:
+        return self._parsed
+
+
+class _ChatCompletionsRawResponse:
+    """``with_raw_response`` accessor for :class:`_ChatCompletions`."""
+
+    def __init__(self, completions: "_ChatCompletions") -> None:
+        self._completions = completions
+
+    async def create(self, **kwargs: Any) -> _RawResponseWrapper[ChatCompletion]:
+        result = await self._completions.create(**kwargs)
+        return _RawResponseWrapper(result)
+
+
+class _EmbeddingsRawResponse:
+    """``with_raw_response`` accessor for :class:`_Embeddings`."""
+
+    def __init__(self, embeddings: "_Embeddings") -> None:
+        self._embeddings = embeddings
+
+    async def create(
+        self, **kwargs: Any
+    ) -> _RawResponseWrapper[CreateEmbeddingResponse]:
+        result = await self._embeddings.create(**kwargs)
+        return _RawResponseWrapper(result)
+
+
+class _ResponsesRawResponse:
+    """``with_raw_response`` accessor for :class:`_Responses`."""
+
+    def __init__(self, responses: "_Responses") -> None:
+        self._responses = responses
+
+    async def create(self, **kwargs: Any) -> _RawResponseWrapper[Response]:
+        result = await self._responses.create(**kwargs)
+        return _RawResponseWrapper(result)
+
+
 @dataclass
 class _ActiveBatch:
     """A batch that has been submitted and is being polled."""
@@ -69,6 +133,18 @@ class _ChatCompletions:
 
     def __init__(self, client: BatchOpenAI):
         self._client = client
+
+    @property
+    def with_raw_response(self) -> _ChatCompletionsRawResponse:
+        """Mimic the openai SDK's ``with_raw_response`` accessor.
+
+        Returns an object whose ``.create()`` awaits the parent ``.create()``
+        and wraps the result in a :class:`_RawResponseWrapper` exposing
+        ``.parse()``, ``.headers``, and ``.http_response``. Required for
+        consumers like ``langchain-openai`` that read response headers via
+        the legacy raw-response surface.
+        """
+        return _ChatCompletionsRawResponse(self)
 
     async def create(
         self,
@@ -102,6 +178,14 @@ class _Embeddings:
     def __init__(self, client: BatchOpenAI):
         self._client = client
 
+    @property
+    def with_raw_response(self) -> _EmbeddingsRawResponse:
+        """Mimic the openai SDK's ``with_raw_response`` accessor.
+
+        See :meth:`_ChatCompletions.with_raw_response` for the rationale.
+        """
+        return _EmbeddingsRawResponse(self)
+
     async def create(
         self,
         *,
@@ -126,6 +210,14 @@ class _Responses:
 
     def __init__(self, client: BatchOpenAI):
         self._client = client
+
+    @property
+    def with_raw_response(self) -> _ResponsesRawResponse:
+        """Mimic the openai SDK's ``with_raw_response`` accessor.
+
+        See :meth:`_ChatCompletions.with_raw_response` for the rationale.
+        """
+        return _ResponsesRawResponse(self)
 
     async def create(
         self,

--- a/src/autobatcher/client.py
+++ b/src/autobatcher/client.py
@@ -419,13 +419,14 @@ class BatchOpenAI:
             )
             logger.debug("Uploaded batch file: {}", file_response.id)
 
-            # Create the batch
-            # completion_window cast: we accept "1h" (Doubleword extension) which
-            # the OpenAI SDK doesn't include in its Literal type.
+            # Create the batch.
+            # The openai SDK types `completion_window` as Literal["24h"], but
+            # Doubleword supports a "1h" extension. Suppress the type error;
+            # the runtime accepts both values.
             batch_response = await self._openai.batches.create(
                 input_file_id=file_response.id,
                 endpoint=top_level_endpoint,
-                completion_window=self._completion_window,  # type: ignore[arg-type]
+                completion_window=self._completion_window,  # ty: ignore[invalid-argument-type]
             )
             logger.info("Submitted batch {} with {} requests", batch_response.id, len(requests))
 

--- a/tests/test_with_raw_response.py
+++ b/tests/test_with_raw_response.py
@@ -1,0 +1,133 @@
+"""Tests for the ``with_raw_response`` accessor on chat / embeddings / responses.
+
+These exist because consumers like ``langchain-openai`` call
+``await client.chat.completions.with_raw_response.create(**payload)``
+unconditionally on their non-streaming async path, then call ``.parse()`` on
+the result. The proxies need to expose the same surface as the openai SDK's
+``with_raw_response`` accessor for those consumers to work against
+``BatchOpenAI``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openai.types.chat import ChatCompletion
+from openai.types import CreateEmbeddingResponse
+from openai.types.responses import Response
+
+from autobatcher.client import (
+    BatchOpenAI,
+    _ChatCompletionsRawResponse,
+    _EmbeddingsRawResponse,
+    _RawResponseWrapper,
+    _ResponsesRawResponse,
+)
+from tests.conftest import (
+    make_chat_completion,
+    make_embedding_response,
+    make_response_api_result,
+)
+
+
+class TestRawResponseWrapper:
+    """The wrapper itself — has the three attributes consumers read."""
+
+    def test_parse_returns_underlying_value(self) -> None:
+        sentinel = object()
+        wrapper = _RawResponseWrapper(sentinel)
+        assert wrapper.parse() is sentinel
+
+    def test_headers_is_empty_dict(self) -> None:
+        wrapper = _RawResponseWrapper("anything")
+        assert wrapper.headers == {}
+        assert isinstance(wrapper.headers, dict)
+
+    def test_http_response_is_none(self) -> None:
+        wrapper = _RawResponseWrapper("anything")
+        assert wrapper.http_response is None
+
+
+class TestChatCompletionsWithRawResponse:
+    async def test_with_raw_response_returns_accessor(self, client: BatchOpenAI) -> None:
+        accessor = client.chat.completions.with_raw_response
+        assert isinstance(accessor, _ChatCompletionsRawResponse)
+
+    async def test_create_wraps_parsed_chat_completion(
+        self, client: BatchOpenAI
+    ) -> None:
+        # Bypass the batching path: pretend the enqueued request resolved to a
+        # parsed ChatCompletion immediately.
+        parsed = ChatCompletion.model_validate(make_chat_completion("hi"))
+        client._enqueue_request = AsyncMock(return_value=parsed)  # type: ignore[method-assign]
+
+        raw = await client.chat.completions.with_raw_response.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        assert isinstance(raw, _RawResponseWrapper)
+        assert raw.parse() is parsed
+        assert raw.headers == {}
+        assert raw.http_response is None
+
+    async def test_create_forwards_kwargs(self, client: BatchOpenAI) -> None:
+        captured: dict = {}
+
+        async def fake_enqueue(**kwargs):  # type: ignore[no-untyped-def]
+            captured.update(kwargs.get("params", {}))
+            return ChatCompletion.model_validate(make_chat_completion("ok"))
+
+        client._enqueue_request = fake_enqueue  # type: ignore[method-assign]
+
+        await client.chat.completions.with_raw_response.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.5,
+        )
+        assert captured["model"] == "gpt-4o"
+        assert captured["temperature"] == 0.5
+
+
+class TestEmbeddingsWithRawResponse:
+    async def test_with_raw_response_returns_accessor(self, client: BatchOpenAI) -> None:
+        accessor = client.embeddings.with_raw_response
+        assert isinstance(accessor, _EmbeddingsRawResponse)
+
+    async def test_create_wraps_parsed_embedding_response(
+        self, client: BatchOpenAI
+    ) -> None:
+        parsed = CreateEmbeddingResponse.model_validate(make_embedding_response())
+        client._enqueue_request = AsyncMock(return_value=parsed)  # type: ignore[method-assign]
+
+        raw = await client.embeddings.with_raw_response.create(
+            model="text-embedding-3-small",
+            input="hello",
+        )
+
+        assert isinstance(raw, _RawResponseWrapper)
+        assert raw.parse() is parsed
+        assert raw.headers == {}
+        assert raw.http_response is None
+
+
+class TestResponsesWithRawResponse:
+    async def test_with_raw_response_returns_accessor(self, client: BatchOpenAI) -> None:
+        accessor = client.responses.with_raw_response
+        assert isinstance(accessor, _ResponsesRawResponse)
+
+    async def test_create_wraps_parsed_response(self, client: BatchOpenAI) -> None:
+        parsed = Response.model_validate(make_response_api_result())
+        client._enqueue_request = AsyncMock(return_value=parsed)  # type: ignore[method-assign]
+
+        raw = await client.responses.with_raw_response.create(
+            model="gpt-4o",
+            input="hello",
+        )
+
+        assert isinstance(raw, _RawResponseWrapper)
+        assert raw.parse() is parsed
+        assert raw.headers == {}
+        assert raw.http_response is None


### PR DESCRIPTION
## Summary

Three small things, all driven by the same root cause (autobatcher needs to honour more of the `openai.AsyncOpenAI` contract):

1. Adds `with_raw_response` accessors to `_ChatCompletions`, `_Embeddings`, and `_Responses`. This is part of the `openai.AsyncOpenAI` contract that `BatchOpenAI` claims to be a drop-in replacement for, and `langchain-openai` relies on it.
2. Bumps the `openai` dependency from `>=1.66.0` (unbounded) to `>=2.0.0,<3`. This is the version that's actually been tested.
3. Switches the existing inline type suppression from mypy syntax (`# type: ignore[arg-type]`) to ty syntax (`# ty: ignore[invalid-argument-type]`) so it actually works.

## Why

`langchain-openai`'s `BaseChatOpenAI._agenerate` calls:

```python
raw_response = await self.async_client.with_raw_response.create(**payload)
response = raw_response.parse()
```

unconditionally on its non-streaming async path. `with_raw_response` is part of the standard `openai.AsyncOpenAI` SDK surface -- see [`AsyncCompletionsWithRawResponse`](https://github.com/openai/openai-python/blob/main/src/openai/resources/chat/completions/completions.py), which has been in the openai SDK for years.

`self.async_client` expects something shaped like `openai.AsyncOpenAI().chat.completions`. When it's autobatcher's own `_ChatCompletions` proxy (from `BatchOpenAI`), the attribute doesn't exist, so the line raises:

```
AttributeError: '_ChatCompletions' object has no attribute 'with_raw_response'
```

before any model call happens. Any consumer using the raw-response surface against a `BatchOpenAI` instance fails the same way. We hit it via `langchain-doubleword`'s `ChatDoublewordBatch`, which wires autobatcher into LangChain/LangGraph.

## Changes

In `client.py`:

- **`_RawResponseWrapper[V]`** -- duck-typed stand-in for `LegacyAPIResponse`. Exposes:
  - `.parse()` -- the parsed body
  - `.headers` -- `{}` (batches have no per-request headers)
  - `.http_response` -- `None`
- **`_ChatCompletionsRawResponse`** / **`_EmbeddingsRawResponse`** / **`_ResponsesRawResponse`** -- per-resource accessors whose `.create()` awaits the parent proxy's `.create()` and wraps the result.
- A `with_raw_response` `@property` on each of `_ChatCompletions`, `_Embeddings`, `_Responses`.

The wrapper is duck-typed rather than a real `LegacyAPIResponse` because the SDK's `async_to_raw_response_wrapper` helper relies on injecting a `RAW_RESPONSE_HEADER` into kwargs that only the SDK's HTTP layer understands -- our `.create()` goes through a batch poll instead. Consumers that read `.parse()` / `.headers` / `.http_response` work; `isinstance(raw, LegacyAPIResponse)` would not.

## openai version bump

`pyproject.toml`: `openai>=1.66.0` -> `openai>=2.0.0,<3`.

The previous lower bound was the version originally tested. The currently-installed version (and what I tested against) is `2.31.0`, picked up by pip because there was no upper bound. The dep range was lying about what actually ships; bumping makes it honest. The `<3` upper bound prevents a future openai 3.x from silently breaking us on the next CI run.

The only documented breaking change in [openai 2.0.0](https://github.com/openai/openai-python/releases/tag/v2.0.0) is on `ResponseFunctionToolCallOutputItem.output` and `ResponseCustomToolCallOutput.output`. Autobatcher does `Response.model_validate(...)` on the top-level `Response` only and never reads those sub-objects, so it's not affected. Files, batches, chat completions and embeddings call sites are all unchanged.

End-to-end verified against openai 2.31:

- `uv run pytest`: 70 passed
- `langchain-doubleword`'s `examples/langgraph-basic/batched.py` against real Doubleword: chat completions batched flow works through the new `with_raw_response` shim
- Embeddings + Responses batched paths share the same `_enqueue_request` call path; not separately runtime-tested

## ty suppression syntax fix

`_submit_batch` passes `completion_window=self._completion_window` (type `Literal["24h", "1h"]`) to `openai.batches.create`, which only accepts `Literal["24h"]`. Doubleword's "1h" is a server-side extension the SDK doesn't model. The line has had a `# type: ignore[arg-type]` suppression for a long time.

The suppression is mypy syntax. ty doesn't honour it, so it has been silently broken since ty was added to CI in commit 2846e66. It only surfaced now because openai 2.31 tightened the inference path enough for ty to flag the underlying mismatch.

Fix: switch to `# ty: ignore[invalid-argument-type]`.

## Tests

New file `tests/test_with_raw_response.py` -- 10 tests covering the wrapper's three attributes, each proxy's accessor, round-trip kwargs forwarding, and the `.create()` -> `.parse()` path on all three resources.

Full suite: 70 passed (was 60). `ty check`: clean.
