### PR TITLE
fix: docstring for add_raw_response

### DIFF
--- a/src/autobatcher/client.py
+++ b/src/autobatcher/client.py
@@ -62,7 +62,7 @@ class _RawResponseWrapper(Generic[V]):
 
     .. code-block:: python
 
-        raw_response = await self.async_client.with_raw_response.create(**payload)
+        raw_response = await client.chat.completions.with_raw_response.create(**payload)
         response = raw_response.parse()
 
     Batch results don't have meaningful per-request HTTP metadata (everything


### PR DESCRIPTION
## Summary

Follow-up to #14 addressing the Copilot review [comment](https://github.com/doublewordai/autobatcher/pull/14#discussion_r3072289974) that was left before that PR was merged.

The `_RawResponseWrapper` docstring describes the SDK surface as `client.chat.completions.with_raw_response.create(...)`, but the inline example used `self.async_client.with_raw_response.create(**payload)`, which reads as if `with_raw_response` lives on the top-level client. Switching the example to the fully-qualified form matches the surrounding prose.

## Test plan

- [ ] Docstring-only change; no behavioural impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)