### PR TITLE
fix(cli): allow arbitrary completion window strings

### DIFF
--- a/src/autobatcher/__main__.py
+++ b/src/autobatcher/__main__.py
@@ -33,7 +33,11 @@ def main() -> None:
     serve.add_argument("--batch-size", type=int, default=1000, help="Max requests per batch (default: 1000)")
     serve.add_argument("--batch-window", type=float, default=10.0, help="Batch window in seconds (default: 10)")
     serve.add_argument("--poll-interval", type=float, default=5.0, help="Poll interval in seconds (default: 5)")
-    serve.add_argument("--completion-window", default="24h", choices=["24h", "1h"], help="Batch completion window (default: 24h)")
+    serve.add_argument(
+        "--completion-window",
+        default="24h",
+        help="Batch completion window passed through to the upstream API (default: 24h)",
+    )
 
     args = parser.parse_args()
 

--- a/src/autobatcher/client.py
+++ b/src/autobatcher/client.py
@@ -271,7 +271,7 @@ class BatchOpenAI:
         batch_size: int = 1000,
         batch_window_seconds: float = 10.0,
         poll_interval_seconds: float = 5.0,
-        completion_window: Literal["24h", "1h"] = "24h",
+        completion_window: str = "24h",
         **openai_kwargs: Any,
     ):
         """
@@ -283,7 +283,7 @@ class BatchOpenAI:
             batch_size: Submit batch when this many requests are queued
             batch_window_seconds: Submit batch after this many seconds, even if size not reached
             poll_interval_seconds: How often to poll for batch completion
-            completion_window: Batch completion window ("24h" or "1h")
+            completion_window: Batch completion window passed through to the upstream API
             **openai_kwargs: Additional arguments passed to AsyncOpenAI
         """
         self._openai = AsyncOpenAI(
@@ -420,9 +420,9 @@ class BatchOpenAI:
             logger.debug("Uploaded batch file: {}", file_response.id)
 
             # Create the batch.
-            # The openai SDK types `completion_window` as Literal["24h"], but
-            # Doubleword supports a "1h" extension. Suppress the type error;
-            # the runtime accepts both values.
+            # The openai SDK types `completion_window` narrowly, but some
+            # OpenAI-compatible providers accept additional values. Pass the
+            # caller-provided string through unchanged.
             batch_response = await self._openai.batches.create(
                 input_file_id=file_response.id,
                 endpoint=top_level_endpoint,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sys
+
+import autobatcher.__main__ as cli
+import autobatcher.serve as serve
+
+
+def test_cli_accepts_arbitrary_completion_window(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_server(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(serve, "run_server", fake_run_server)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "autobatcher",
+            "serve",
+            "--api-key",
+            "sk-test",
+            "--completion-window",
+            "72h",
+        ],
+    )
+
+    cli.main()
+
+    assert captured["completion_window"] == "72h"

--- a/tests/test_submit_batch.py
+++ b/tests/test_submit_batch.py
@@ -88,6 +88,20 @@ class TestSubmitBatch:
         assert call_kwargs["endpoint"] == "/v1/chat/completions"
         assert call_kwargs["completion_window"] == "24h"
 
+    async def test_batches_create_passes_through_arbitrary_completion_window(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Nonstandard completion_window values should be passed through unchanged."""
+        file_obj = make_file_object("file-xyz")
+        client._openai.files.create.return_value = file_obj
+        client._completion_window = "72h"
+
+        _add_pending(client, 1)
+        await client._submit_batch()
+
+        call_kwargs = client._openai.batches.create.call_args.kwargs
+        assert call_kwargs["completion_window"] == "72h"
+
     async def test_active_batches_populated(self, client: BatchOpenAI) -> None:
         """After submission, _active_batches should contain the batch with correct request map."""
         batch_resp = make_batch(


### PR DESCRIPTION
## Summary
- remove the CLI restriction that only allowed `1h` and `24h` completion windows
- pass arbitrary `completion_window` strings through the `BatchOpenAI` client unchanged
- add regression coverage for both the CLI surface and batch submission plumbing

## Why
Doubleword supports longer completion windows for low-priority eval workloads. `autobatcher` was blocking those values at the CLI layer even though the rest of the client/server path already treated the setting as a plain string.

## Validation
- `uv run --extra serve --extra test python -m pytest`
