### PR TITLE
feat(serve): emit structured batch lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # autobatcher
 
-Drop-in replacement for `AsyncOpenAI` that transparently batches requests. This library is designed or use with the [Doubleword Batch API](https://docs.doubleword.ai/batches/getting-started-with-batched-api). Support for OpenAI's batch API or other compatible APIs is best effort. If you experience any issues, please open an issue.
+Drop-in replacement for `AsyncOpenAI` that transparently batches requests. This library is designed for use with the [Doubleword Batch API](https://docs.doubleword.ai/batches/getting-started-with-batched-api). Support for OpenAI's batch API or other compatible APIs is best effort. If you experience any issues, please open an issue.
  
 ## Why?
 
@@ -131,6 +131,106 @@ async with BatchOpenAI() as client:
     response = await client.chat.completions.create(...)
 ```
 
+## Serve mode
+
+`autobatcher serve` runs a local OpenAI-compatible HTTP proxy. This is useful
+when you want to transparently batch traffic from tools that already support an
+OpenAI-style `base_url`, such as evaluation frameworks, SDK consumers, or local
+benchmark runners.
+
+```bash
+autobatcher serve \
+  --base-url https://api.doubleword.ai/v1 \
+  --api-key "$OPENAI_API_KEY" \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --batch-size 1024 \
+  --batch-window 60 \
+  --poll-interval 10 \
+  --completion-window 24h
+```
+
+Then point your OpenAI-compatible client at the proxy:
+
+```bash
+export OPENAI_BASE_URL=http://127.0.0.1:8080/v1
+export OPENAI_API_KEY=dummy
+```
+
+Supported proxy routes:
+
+| Route | Upstream batched endpoint |
+|-------|----------------------------|
+| `/v1/chat/completions` | `/v1/chat/completions` |
+| `/v1/embeddings` | `/v1/embeddings` |
+| `/v1/responses` | `/v1/responses` |
+| `/health` | local healthcheck |
+
+### Batch lifecycle events
+
+In `serve` mode, autobatcher emits structured JSON lines to stdout for batch
+lifecycle events. These are intended for log collection systems such as
+Kubernetes logs, Loki, or Cloud Logging.
+
+Example event:
+
+```json
+{
+  "batch_id": "batch_123",
+  "completion_window": "24h",
+  "endpoint": "/v1/chat/completions",
+  "event": "batch_submitted",
+  "input_file_id": "file_123",
+  "metadata": {
+    "benchmark_id": "bench-2026-04-14",
+    "github_run_id": "24393857047"
+  },
+  "models": ["Qwen/Qwen3.5-397B-A17B-FP8"],
+  "request_count": 872,
+  "source": "autobatcher",
+  "ts": 1776163751.821
+}
+```
+
+Emitted events currently include:
+
+- `batch_submitted`
+- `batch_progress`
+- `batch_completed`
+- `batch_terminal`
+- `batch_cancel_requested`
+- `batch_cancelled_upstream`
+- `batch_cancel_failed`
+- `client_closing`
+
+### Batch metadata
+
+You can stamp correlation metadata onto every upstream batch:
+
+```bash
+autobatcher serve \
+  --base-url https://api.doubleword.ai/v1 \
+  --api-key "$OPENAI_API_KEY" \
+  --batch-metadata benchmark_id=bench-2026-04-14 \
+  --batch-metadata github_run_id=24393857047 \
+  --batch-metadata k8s_job=perf-1234
+```
+
+This metadata is passed through to the upstream `batches.create(...)` call and
+is also included in the emitted lifecycle events.
+
+### Shutdown behavior
+
+By default, `serve` mode best-effort cancels any still-active upstream batches
+when the proxy shuts down. This is useful for short-lived pods or CI jobs where
+the proxy lifetime should own the batch lifetime.
+
+If you want upstream batches to continue running after the proxy exits, use:
+
+```bash
+autobatcher serve --keep-active-batches-on-close
+```
+
 ## Configuration
 
 | Parameter | Default | Description |
@@ -140,7 +240,9 @@ async with BatchOpenAI() as client:
 | `batch_size` | `1000` | Submit batch when this many requests are queued |
 | `batch_window_seconds` | `10.0` | Submit batch after this many seconds |
 | `poll_interval_seconds` | `5.0` | How often to poll for batch completion |
-| `completion_window` | `"24h"` | Batch completion window (`"24h"` or `"1h"`) |
+| `completion_window` | `"24h"` | Batch completion window passed through to the upstream API |
+| `batch_metadata` | `None` | Optional metadata attached to each upstream batch |
+| `cancel_active_batches_on_close` | `False` | Best-effort cancel active upstream batches when closing the client |
 
 ## Supported endpoints
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ benchmark runners.
 ```bash
 autobatcher serve \
   --base-url https://api.doubleword.ai/v1 \
-  --api-key "$OPENAI_API_KEY" \
+  --api-key "$DOUBLEWORD_API_KEY" \
   --host 127.0.0.1 \
   --port 8080 \
   --batch-size 1024 \
@@ -156,6 +156,10 @@ Then point your OpenAI-compatible client at the proxy:
 export OPENAI_BASE_URL=http://127.0.0.1:8080/v1
 export OPENAI_API_KEY=dummy
 ```
+
+Use your real Doubleword credential for the proxy's upstream `--api-key`. The
+downstream client still uses a dummy `OPENAI_API_KEY` because it is only talking
+to the local OpenAI-compatible proxy.
 
 Supported proxy routes:
 
@@ -210,7 +214,7 @@ You can stamp correlation metadata onto every upstream batch:
 ```bash
 autobatcher serve \
   --base-url https://api.doubleword.ai/v1 \
-  --api-key "$OPENAI_API_KEY" \
+  --api-key "$DOUBLEWORD_API_KEY" \
   --batch-metadata benchmark_id=bench-2026-04-14 \
   --batch-metadata github_run_id=24393857047 \
   --batch-metadata k8s_job=perf-1234

--- a/src/autobatcher/__main__.py
+++ b/src/autobatcher/__main__.py
@@ -7,6 +7,22 @@ import os
 import sys
 
 
+def _parse_batch_metadata(items: list[str] | None) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for item in items or []:
+        if "=" not in item:
+            raise argparse.ArgumentTypeError(
+                f"Invalid --batch-metadata value {item!r}; expected KEY=VALUE"
+            )
+        key, value = item.split("=", 1)
+        if not key:
+            raise argparse.ArgumentTypeError(
+                f"Invalid --batch-metadata value {item!r}; key must be non-empty"
+            )
+        metadata[key] = value
+    return metadata
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="autobatcher",
@@ -38,6 +54,18 @@ def main() -> None:
         default="24h",
         help="Batch completion window passed through to the upstream API (default: 24h)",
     )
+    serve.add_argument(
+        "--batch-metadata",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Repeatable metadata key/value attached to upstream batches",
+    )
+    serve.add_argument(
+        "--keep-active-batches-on-close",
+        action="store_true",
+        help="Do not cancel in-flight upstream batches when the proxy shuts down",
+    )
 
     args = parser.parse_args()
 
@@ -52,6 +80,12 @@ def main() -> None:
 
         from .serve import run_server
 
+        try:
+            batch_metadata = _parse_batch_metadata(args.batch_metadata)
+        except argparse.ArgumentTypeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(2)
+
         run_server(
             base_url=args.base_url,
             api_key=args.api_key,
@@ -61,6 +95,8 @@ def main() -> None:
             batch_window_seconds=args.batch_window,
             poll_interval_seconds=args.poll_interval,
             completion_window=args.completion_window,
+            batch_metadata=batch_metadata,
+            cancel_active_batches_on_close=not args.keep_active_batches_on_close,
         )
 
 

--- a/src/autobatcher/client.py
+++ b/src/autobatcher/client.py
@@ -15,6 +15,7 @@ import json
 import io
 import uuid
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Generic, Literal, Protocol, TypeVar
 
@@ -41,6 +42,7 @@ class _Validatable(Protocol):
 
 
 V = TypeVar("V", bound=_Validatable)
+BatchEventHandler = Callable[[dict[str, Any]], None]
 
 
 # ---------------------------------------------------------------------------
@@ -139,12 +141,20 @@ class _ActiveBatch:
 
     batch_id: str
     endpoint: str
+    input_file_id: str
     output_file_id: str
     error_file_id: str
+    request_count: int
     requests: dict[str, _PendingRequest[Any]]  # custom_id -> request
     created_at: float
+    models: tuple[str, ...] = ()
+    metadata: dict[str, str] = field(default_factory=dict)
     result_types: dict[str, type[_Validatable]] = field(default_factory=dict)  # custom_id -> result type
     last_offset: int = 0  # Track offset for partial result streaming
+    last_status: str | None = None
+    last_completed_count: int = -1
+    last_failed_count: int = -1
+    last_total_count: int = -1
 
 
 # ---------------------------------------------------------------------------
@@ -303,6 +313,9 @@ class BatchOpenAI(AsyncOpenAI):
         batch_window_seconds: float = 10.0,
         poll_interval_seconds: float = 5.0,
         completion_window: str = "24h",
+        batch_metadata: dict[str, str] | None = None,
+        batch_event_handler: BatchEventHandler | None = None,
+        cancel_active_batches_on_close: bool = False,
         **openai_kwargs: Any,
     ):
         """
@@ -315,6 +328,9 @@ class BatchOpenAI(AsyncOpenAI):
             batch_window_seconds: Submit batch after this many seconds, even if size not reached
             poll_interval_seconds: How often to poll for batch completion
             completion_window: Batch completion window passed through to the upstream API
+            batch_metadata: Optional metadata attached to upstream batches
+            batch_event_handler: Optional callback for structured batch lifecycle events
+            cancel_active_batches_on_close: Best-effort cancel for in-flight upstream batches on close()
             **openai_kwargs: Additional arguments passed to AsyncOpenAI
         """
         super().__init__(
@@ -329,6 +345,10 @@ class BatchOpenAI(AsyncOpenAI):
         self._batch_window_seconds = batch_window_seconds
         self._poll_interval_seconds = poll_interval_seconds
         self._completion_window = completion_window
+        self._batch_metadata = dict(batch_metadata or {})
+        self._batch_event_handler = batch_event_handler
+        self._cancel_active_batches_on_close = cancel_active_batches_on_close
+        self._closed = False
 
         # HTTP client for raw requests (needed for partial result streaming headers)
         self._http_client = httpx.AsyncClient(
@@ -354,6 +374,23 @@ class BatchOpenAI(AsyncOpenAI):
 
         logger.debug("Initialized with batch_size={}, window={}s", batch_size, batch_window_seconds)
 
+    def _emit_batch_event(self, event: str, **payload: Any) -> None:
+        """Emit a structured batch lifecycle event to the configured handler."""
+        if self._batch_event_handler is None:
+            return
+
+        body = {
+            "source": "autobatcher",
+            "event": event,
+            "ts": time.time(),
+            **payload,
+        }
+
+        try:
+            self._batch_event_handler(body)
+        except Exception as exc:
+            logger.warning("Batch event handler failed for {}: {}", event, exc)
+
     async def _enqueue_request(
         self,
         *,
@@ -362,6 +399,9 @@ class BatchOpenAI(AsyncOpenAI):
         params: dict[str, Any],
     ) -> V:
         """Add a request to the pending queue and return when result is ready."""
+        if self._closed:
+            raise RuntimeError("BatchOpenAI is closed")
+
         loop = asyncio.get_running_loop()
         future: asyncio.Future[V] = loop.create_future()
 
@@ -444,6 +484,9 @@ class BatchOpenAI(AsyncOpenAI):
 
         # Use the first request's endpoint for the top-level batches.create() call
         top_level_endpoint = requests[0].endpoint
+        models = tuple(sorted({
+            model for req in requests for model in [req.params.get("model")] if isinstance(model, str)
+        }))
 
         try:
             # Upload the batch file
@@ -460,24 +503,44 @@ class BatchOpenAI(AsyncOpenAI):
             # The openai SDK types `completion_window` narrowly, but some
             # OpenAI-compatible providers accept additional values. Pass the
             # caller-provided string through unchanged.
-            batch_response = await self.batches.create(
-                input_file_id=file_response.id,
-                endpoint=top_level_endpoint,
-                completion_window=self._completion_window,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-            )
+            batch_create_kwargs: dict[str, Any] = {
+                "input_file_id": file_response.id,
+                "endpoint": top_level_endpoint,
+                "completion_window": self._completion_window,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+            }
+            if self._batch_metadata:
+                batch_create_kwargs["metadata"] = self._batch_metadata
+
+            batch_response = await self.batches.create(**batch_create_kwargs)
             logger.info("Submitted batch {} with {} {} requests", batch_response.id, len(requests), endpoint)
 
             # Track the active batch
             active_batch = _ActiveBatch(
                 batch_id=batch_response.id,
-                endpoint=endpoint,
+                endpoint=top_level_endpoint,
+                input_file_id=file_response.id,
                 output_file_id=batch_response.output_file_id or "",
                 error_file_id=batch_response.error_file_id or "",
+                request_count=len(requests),
                 requests={req.custom_id: req for req in requests},
                 created_at=time.time(),
+                models=models,
+                metadata=dict(self._batch_metadata),
                 result_types={req.custom_id: req.result_type for req in requests},
             )
             self._active_batches.append(active_batch)
+            self._emit_batch_event(
+                "batch_submitted",
+                batch_id=batch_response.id,
+                endpoint=top_level_endpoint,
+                input_file_id=file_response.id,
+                output_file_id=batch_response.output_file_id,
+                error_file_id=batch_response.error_file_id,
+                request_count=len(requests),
+                models=list(models),
+                completion_window=self._completion_window,
+                metadata=dict(self._batch_metadata),
+            )
 
             # Start the poller if not running
             if self._poller_task is None or self._poller_task.done():
@@ -488,6 +551,15 @@ class BatchOpenAI(AsyncOpenAI):
 
         except Exception as e:
             logger.error("Batch submission failed: {}", e)
+            self._emit_batch_event(
+                "batch_submission_failed",
+                endpoint=top_level_endpoint,
+                request_count=len(requests),
+                models=list(models),
+                completion_window=self._completion_window,
+                metadata=dict(self._batch_metadata),
+                error=str(e),
+            )
             for req in requests:
                 if not req.future.done():
                     req.future.set_exception(e)
@@ -505,21 +577,74 @@ class BatchOpenAI(AsyncOpenAI):
                 try:
                     status = await self.batches.retrieve(batch.batch_id)
                     counts = status.request_counts
+                    completed_count = counts.completed if counts else 0
+                    failed_count = getattr(counts, "failed", 0) if counts else 0
+                    total_count = counts.total if counts else batch.request_count
                     logger.debug(
                         "Batch {} status: {} (completed={}/{})",
                         batch.batch_id[:12], status.status,
-                        counts.completed if counts else 0,
-                        counts.total if counts else 0
+                        completed_count,
+                        total_count
                     )
 
                     # Update output_file_id if it becomes available
                     if status.output_file_id and not batch.output_file_id:
                         batch.output_file_id = status.output_file_id
+                    if status.error_file_id and not batch.error_file_id:
+                        batch.error_file_id = status.error_file_id
+
+                    if (
+                        status.status != batch.last_status
+                        or completed_count != batch.last_completed_count
+                        or failed_count != batch.last_failed_count
+                        or total_count != batch.last_total_count
+                    ):
+                        self._emit_batch_event(
+                            "batch_progress",
+                            batch_id=batch.batch_id,
+                            endpoint=batch.endpoint,
+                            input_file_id=batch.input_file_id,
+                            output_file_id=batch.output_file_id or None,
+                            error_file_id=batch.error_file_id or None,
+                            request_count=batch.request_count,
+                            counts={
+                                "completed": completed_count,
+                                "failed": failed_count,
+                                "total": total_count,
+                            },
+                            status=status.status,
+                            models=list(batch.models),
+                            completion_window=self._completion_window,
+                            metadata=dict(batch.metadata),
+                            elapsed_seconds=round(time.time() - batch.created_at, 3),
+                        )
+                        batch.last_status = status.status
+                        batch.last_completed_count = completed_count
+                        batch.last_failed_count = failed_count
+                        batch.last_total_count = total_count
 
                     if status.status == "completed":
                         await self._process_completed_batch(batch, status.output_file_id)
                         completed_indices.append(i)
                         logger.info("Batch {} completed", batch.batch_id)
+                        self._emit_batch_event(
+                            "batch_completed",
+                            batch_id=batch.batch_id,
+                            endpoint=batch.endpoint,
+                            input_file_id=batch.input_file_id,
+                            output_file_id=batch.output_file_id or None,
+                            error_file_id=batch.error_file_id or None,
+                            request_count=batch.request_count,
+                            counts={
+                                "completed": completed_count,
+                                "failed": failed_count,
+                                "total": total_count,
+                            },
+                            models=list(batch.models),
+                            completion_window=self._completion_window,
+                            metadata=dict(batch.metadata),
+                            elapsed_seconds=round(time.time() - batch.created_at, 3),
+                        )
                     elif status.status in ("failed", "expired", "cancelled"):
                         logger.error("Batch {} {}", batch.batch_id, status.status)
                         error = Exception(f"Batch {batch.batch_id} {status.status}")
@@ -527,6 +652,25 @@ class BatchOpenAI(AsyncOpenAI):
                             if not req.future.done():
                                 req.future.set_exception(error)
                         completed_indices.append(i)
+                        self._emit_batch_event(
+                            "batch_terminal",
+                            batch_id=batch.batch_id,
+                            endpoint=batch.endpoint,
+                            input_file_id=batch.input_file_id,
+                            output_file_id=batch.output_file_id or None,
+                            error_file_id=batch.error_file_id or None,
+                            request_count=batch.request_count,
+                            counts={
+                                "completed": completed_count,
+                                "failed": failed_count,
+                                "total": total_count,
+                            },
+                            status=status.status,
+                            models=list(batch.models),
+                            completion_window=self._completion_window,
+                            metadata=dict(batch.metadata),
+                            elapsed_seconds=round(time.time() - batch.created_at, 3),
+                        )
                     elif status.status in ("in_progress", "validating", "finalizing"):
                         # Fetch partial results if output file is available
                         if batch.output_file_id:
@@ -642,10 +786,81 @@ class BatchOpenAI(AsyncOpenAI):
 
     async def close(self) -> None:
         """Close the client and cancel any pending operations."""
+        if self._closed:
+            return
+        self._closed = True
+
+        pending_count = sum(len(reqs) for reqs in self._pending.values())
+        active_batch_ids = [batch.batch_id for batch in self._active_batches]
+        self._emit_batch_event(
+            "client_closing",
+            pending_request_count=pending_count,
+            active_batch_ids=active_batch_ids,
+            cancel_active_batches_on_close=self._cancel_active_batches_on_close,
+        )
+
         for task in self._window_tasks.values():
             if not task.done():
                 task.cancel()
+        if self._window_tasks:
+            await asyncio.gather(*self._window_tasks.values(), return_exceptions=True)
+        self._window_tasks.clear()
+
         if self._poller_task and not self._poller_task.done():
             self._poller_task.cancel()
+            await asyncio.gather(self._poller_task, return_exceptions=True)
+        self._poller_task = None
+
+        for endpoint, requests in self._pending.items():
+            for req in requests:
+                if not req.future.done():
+                    req.future.set_exception(
+                        RuntimeError(
+                            f"BatchOpenAI closed before pending request on {endpoint} was submitted"
+                        )
+                    )
+        self._pending.clear()
+
+        if self._cancel_active_batches_on_close:
+            for batch in list(self._active_batches):
+                self._emit_batch_event(
+                    "batch_cancel_requested",
+                    batch_id=batch.batch_id,
+                    endpoint=batch.endpoint,
+                    input_file_id=batch.input_file_id,
+                    output_file_id=batch.output_file_id or None,
+                    error_file_id=batch.error_file_id or None,
+                    request_count=batch.request_count,
+                    models=list(batch.models),
+                    completion_window=self._completion_window,
+                    metadata=dict(batch.metadata),
+                )
+                try:
+                    await self.batches.cancel(batch.batch_id)
+                except Exception as exc:
+                    logger.warning("Failed to cancel upstream batch {} during close: {}", batch.batch_id, exc)
+                    self._emit_batch_event(
+                        "batch_cancel_failed",
+                        batch_id=batch.batch_id,
+                        endpoint=batch.endpoint,
+                        error=str(exc),
+                    )
+                else:
+                    self._emit_batch_event(
+                        "batch_cancelled_upstream",
+                        batch_id=batch.batch_id,
+                        endpoint=batch.endpoint,
+                    )
+
+        for batch in self._active_batches:
+            for req in batch.requests.values():
+                if not req.future.done():
+                    req.future.set_exception(
+                        RuntimeError(
+                            f"BatchOpenAI closed before batch {batch.batch_id} completed"
+                        )
+                    )
+        self._active_batches.clear()
+
         await self._http_client.aclose()
         await super().close()

--- a/src/autobatcher/serve.py
+++ b/src/autobatcher/serve.py
@@ -21,6 +21,11 @@ from loguru import logger
 from .client import BatchOpenAI
 
 
+def _stdout_batch_event_handler(event: dict[str, Any]) -> None:
+    """Write structured batch lifecycle events to stdout as JSON lines."""
+    print(json.dumps(event, sort_keys=True), flush=True)
+
+
 def _chat_completion_to_sse(data: dict[str, Any]) -> bytes:
     """Convert a ChatCompletion into SSE bytes (single chunk + [DONE])."""
     chunk = {
@@ -178,6 +183,8 @@ def run_server(
     batch_window_seconds: float = 10.0,
     poll_interval_seconds: float = 5.0,
     completion_window: str = "24h",
+    batch_metadata: dict[str, str] | None = None,
+    cancel_active_batches_on_close: bool = True,
 ) -> None:
     """Start the autobatcher HTTP proxy server."""
     client = BatchOpenAI(
@@ -187,6 +194,9 @@ def run_server(
         batch_window_seconds=batch_window_seconds,
         poll_interval_seconds=poll_interval_seconds,
         completion_window=completion_window,  # type: ignore[arg-type]
+        batch_metadata=batch_metadata,
+        batch_event_handler=_stdout_batch_event_handler,
+        cancel_active_batches_on_close=cancel_active_batches_on_close,
     )
 
     app = create_app(client)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,7 @@ def make_batch(
     obj.error_file_id = error_file_id
     counts = MagicMock()
     counts.completed = 0
+    counts.failed = 0
     counts.total = 0
     obj.request_counts = counts
     return obj
@@ -162,6 +163,7 @@ def mock_openai() -> AsyncMock:
         return_value=make_batch(status="in_progress", output_file_id=None)
     )
     openai.batches.retrieve = AsyncMock(return_value=make_batch())
+    openai.batches.cancel = AsyncMock(return_value=make_batch(status="cancelled"))
     openai.close = AsyncMock()
     return openai
 
@@ -185,6 +187,10 @@ def client(mock_openai: AsyncMock) -> BatchOpenAI:
     c._batch_window_seconds = 0.05
     c._poll_interval_seconds = 0.05
     c._completion_window = "24h"
+    c._batch_metadata = {}
+    c._batch_event_handler = None
+    c._cancel_active_batches_on_close = False
+    c._closed = False
     c._http_client = AsyncMock(spec=httpx.AsyncClient)
     c._pending = {}
     c._pending_lock = asyncio.Lock()
@@ -227,8 +233,10 @@ def make_active_batch(
     return _ActiveBatch(
         batch_id=batch_id,
         endpoint="/v1/chat/completions",
+        input_file_id="file-in",
         output_file_id=output_file_id,
         error_file_id="",
+        request_count=len(custom_ids),
         requests=requests,
         created_at=time.time(),
         result_types=computed_result_types,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,3 +29,35 @@ def test_cli_accepts_arbitrary_completion_window(monkeypatch) -> None:
     cli.main()
 
     assert captured["completion_window"] == "72h"
+
+
+def test_cli_passes_batch_metadata_and_shutdown_policy(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_server(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(serve, "run_server", fake_run_server)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "autobatcher",
+            "serve",
+            "--api-key",
+            "sk-test",
+            "--batch-metadata",
+            "benchmark_id=bench-123",
+            "--batch-metadata",
+            "suite=livebench",
+            "--keep-active-batches-on-close",
+        ],
+    )
+
+    cli.main()
+
+    assert captured["batch_metadata"] == {
+        "benchmark_id": "bench-123",
+        "suite": "livebench",
+    }
+    assert captured["cancel_active_batches_on_close"] is False

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -7,7 +7,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from autobatcher.client import BatchOpenAI
+from autobatcher.client import BatchOpenAI, _ActiveBatch
+import time
 
 
 class TestClose:
@@ -21,10 +22,12 @@ class TestClose:
 
     async def test_close_cancels_poller_task(self, client: BatchOpenAI) -> None:
         """close() should cancel the poller task."""
-        client._poller_task = asyncio.create_task(asyncio.sleep(100))
+        poller = asyncio.create_task(asyncio.sleep(100))
+        client._poller_task = poller
         await client.close()
         await asyncio.sleep(0)
-        assert client._poller_task.cancelled()
+        assert poller.cancelled()
+        assert client._poller_task is None
 
     async def test_close_calls_http_aclose(self, client: BatchOpenAI) -> None:
         """close() should call _http_client.aclose()."""
@@ -36,3 +39,51 @@ class TestClose:
         assert not client._window_tasks
         assert client._poller_task is None
         await client.close()  # Should not raise
+
+    async def test_close_cancels_active_upstream_batches_when_enabled(
+        self, client: BatchOpenAI
+    ) -> None:
+        """close() should best-effort cancel active upstream batches when configured."""
+        events: list[dict] = []
+        client._batch_event_handler = events.append
+        client._cancel_active_batches_on_close = True
+        response_future: asyncio.Future = asyncio.get_event_loop().create_future()
+        request = type("Req", (), {})()
+        request.future = response_future
+        batch = _ActiveBatch(
+            batch_id="batch-123",
+            endpoint="/v1/chat/completions",
+            input_file_id="file-in",
+            output_file_id="file-out",
+            error_file_id="file-err",
+            request_count=1,
+            requests={"cid-1": request},
+            created_at=time.time(),
+            models=("gpt-4o",),
+        )
+        client._active_batches = [batch]
+
+        await client.close()
+
+        client.batches.cancel.assert_awaited_once_with("batch-123")
+        assert response_future.done()
+        with pytest.raises(RuntimeError, match="batch batch-123 completed"):
+            response_future.result()
+        assert [event["event"] for event in events] == [
+            "client_closing",
+            "batch_cancel_requested",
+            "batch_cancelled_upstream",
+        ]
+
+    async def test_close_fails_pending_requests(self, client: BatchOpenAI) -> None:
+        """close() should fail queued-but-unsubmitted requests."""
+        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        request = type("Req", (), {})()
+        request.future = future
+        client._pending["/v1/chat/completions"] = [request]
+
+        await client.close()
+
+        assert future.done()
+        with pytest.raises(RuntimeError, match="before pending request on /v1/chat/completions was submitted"):
+            future.result()

--- a/tests/test_poll_batches.py
+++ b/tests/test_poll_batches.py
@@ -33,6 +33,45 @@ def _httpx_response(
 
 
 class TestPollBatches:
+    async def test_poll_emits_progress_and_completed_events(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Polling should emit structured progress/completed lifecycle events."""
+        events: list[dict] = []
+        client._batch_event_handler = events.append
+        ab = make_active_batch(["id-a"], batch_id="batch-evt", output_file_id="file-out")
+        client._active_batches.append(ab)
+
+        in_progress = make_batch(status="in_progress", output_file_id="file-out")
+        in_progress.request_counts.completed = 0
+        in_progress.request_counts.failed = 0
+        in_progress.request_counts.total = 1
+
+        completed = make_batch(status="completed", output_file_id="file-out")
+        completed.request_counts.completed = 1
+        completed.request_counts.failed = 0
+        completed.request_counts.total = 1
+
+        client.batches.retrieve.side_effect = [in_progress, completed]
+        client._http_client.get = AsyncMock(
+            return_value=_httpx_response(
+                make_batch_result_line("id-a", "reply-a"),
+                {"X-Incomplete": "false"},
+            )
+        )
+
+        await asyncio.wait_for(client._poll_batches(), timeout=5.0)
+
+        event_names = [event["event"] for event in events]
+        assert event_names == [
+            "batch_progress",
+            "batch_progress",
+            "batch_completed",
+        ]
+        assert events[0]["counts"] == {"completed": 0, "failed": 0, "total": 1}
+        assert events[1]["counts"] == {"completed": 1, "failed": 0, "total": 1}
+        assert events[2]["batch_id"] == "batch-evt"
+
     async def test_completed_batch_resolves_futures(
         self, client: BatchOpenAI
     ) -> None:

--- a/tests/test_submit_batch.py
+++ b/tests/test_submit_batch.py
@@ -106,6 +106,21 @@ class TestSubmitBatch:
         call_kwargs = client.batches.create.call_args.kwargs
         assert call_kwargs["completion_window"] == "72h"
 
+    async def test_batches_create_passes_metadata(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Configured batch metadata should be attached to upstream batches."""
+        client._batch_metadata = {"benchmark_id": "bench-123", "suite": "livebench"}
+
+        _add_pending(client, 1)
+        await client._submit_batch(EP)
+
+        call_kwargs = client.batches.create.call_args.kwargs
+        assert call_kwargs["metadata"] == {
+            "benchmark_id": "bench-123",
+            "suite": "livebench",
+        }
+
     async def test_active_batches_populated(self, client: BatchOpenAI) -> None:
         """After submission, _active_batches should contain the batch with correct request map."""
         batch_resp = make_batch(
@@ -121,6 +136,8 @@ class TestSubmitBatch:
         assert len(client._active_batches) == 1
         ab = client._active_batches[0]
         assert ab.batch_id == "batch-999"
+        assert ab.input_file_id == "file-abc123"
+        assert ab.request_count == 2
         assert set(ab.requests.keys()) == {"cid-0", "cid-1"}
 
     async def test_active_batch_has_result_types(self, client: BatchOpenAI) -> None:
@@ -134,6 +151,34 @@ class TestSubmitBatch:
         ab = client._active_batches[0]
         assert ab.result_types["cid-0"] is ChatCompletion
         assert ab.result_types["cid-1"] is ChatCompletion
+
+    async def test_submission_emits_structured_batch_event(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Submission should emit a structured lifecycle event when configured."""
+        events: list[dict] = []
+        client._batch_event_handler = events.append
+        client._batch_metadata = {"benchmark_id": "bench-123"}
+        client.files.create.return_value = make_file_object("file-xyz")
+        client.batches.create.return_value = make_batch(
+            batch_id="batch-evt",
+            status="in_progress",
+            output_file_id="file-out",
+            error_file_id="file-err",
+        )
+
+        _add_pending(client, 2)
+        await client._submit_batch(EP)
+
+        submitted = [event for event in events if event["event"] == "batch_submitted"]
+        assert len(submitted) == 1
+        assert submitted[0]["batch_id"] == "batch-evt"
+        assert submitted[0]["input_file_id"] == "file-xyz"
+        assert submitted[0]["output_file_id"] == "file-out"
+        assert submitted[0]["error_file_id"] == "file-err"
+        assert submitted[0]["request_count"] == 2
+        assert submitted[0]["models"] == ["gpt-4o"]
+        assert submitted[0]["metadata"] == {"benchmark_id": "bench-123"}
 
     async def test_poller_task_started(self, client: BatchOpenAI) -> None:
         """A poller task should be started after a successful submission."""


### PR DESCRIPTION
## Summary
- emit structured batch lifecycle events from `autobatcher serve` as JSON lines on stdout
- attach optional batch metadata to upstream `batches.create(...)` calls for cross-system correlation
- add best-effort cancellation of active upstream batches on proxy shutdown, enabled by default in server mode

## Details
- add `batch_event_handler`, `batch_metadata`, and `cancel_active_batches_on_close` to `BatchOpenAI`
- emit lifecycle events for submission, progress, completion, terminal states, and shutdown-driven cancellation
- add CLI flags for repeatable `--batch-metadata KEY=VALUE` and `--keep-active-batches-on-close`
- keep library defaults conservative while making server mode observable by default

## Testing
- `uv run python -m pytest`
