### PR TITLE
fix: pin pypa/gh-action-pypi-publish to v1.14.0 (GHSA-vxmw-7h4f-hqxh)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           packages-dir: python/dist
 


### PR DESCRIPTION
## Summary
- Pins `pypa/gh-action-pypi-publish` from the floating `release/v1` tag to `v1.14.0`
- Addresses Oneleet finding **GHSA-vxmw-7h4f-hqxh**: versions <1.13.0 are vulnerable to GitHub Actions expression injection via attacker-controlled branch/tag names in `github.ref_name`
- Patched in 1.13.0; pinning to 1.14.0 (latest) for explicit version visibility

## Risk
Very low impact in practice (per advisory) — our `publish.yml` is triggered by `release: [published]`, not by `push` of arbitrary tags/branches, so the vulnerable expansion path was unlikely to be reachable. Fixing anyway to clear the scanner finding and harden against any future trigger changes.

## Test plan
- [ ] CI passes
- [ ] Next release tagged `autobatcher-v*` publishes to PyPI successfully (will be exercised on the next release; no functional change to the action's behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)