### PR TITLE
feat: use flex polling for async inference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,8 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12"]
+        openai-version: ["latest", "2.0.0"]
     defaults:
       run:
         working-directory: python
@@ -25,6 +26,10 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[test,serve]" ty
 
+      - name: Install minimum supported OpenAI SDK
+        if: matrix.openai-version != 'latest'
+        run: pip install "openai==${{ matrix.openai-version }}"
+
       - name: Type check
         run: ty check
 
@@ -33,6 +38,9 @@ jobs:
 
   typescript:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        openai-version: ["locked", "4.104.0"]
     defaults:
       run:
         working-directory: typescript
@@ -46,6 +54,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Install minimum supported OpenAI SDK
+        if: matrix.openai-version != 'locked'
+        run: npm install --no-save --package-lock=false "openai@${{ matrix.openai-version }}"
 
       - name: Type check
         run: npm run typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # autobatcher — Agent & Developer Guide
 
 This repo contains two SDKs that implement the same concept: a drop-in OpenAI
-client replacement that transparently batches requests via the Batch API.
+client replacement for flex background polling and 24-hour batch inference.
 
 ```
 autobatcher/
@@ -25,10 +25,15 @@ Specifically:
 
 - **Same constructor parameters** (snake_case in Python, camelCase in TypeScript)
 - **Same defaults** — `batchSize: 1000`, `batchWindowSeconds: 10`,
-  `pollIntervalSeconds: 5`, `completionWindow: "1h"`
-- **Same batch lifecycle** — queue → JSONL → file upload → batch create → poll → fetch results → resolve
+  `pollIntervalSeconds: 5`, completion window unset
+- **Same flex lifecycle** — Responses create with `service_tier: "flex"` and
+  `background: true` → poll response ID → adapt result → resolve
+- **Same batch lifecycle** — queue → JSONL → file upload → batch create → poll
+  → fetch results → resolve. Text uses it only for an explicit 24-hour window;
+  embeddings always use it with a 24-hour window.
 - **Same partial-result support** — `X-Incomplete` / `X-Last-Line` headers with `?offset=` query param
-- **Same intercepted endpoints** — `chat.completions.create()`, `embeddings.create()`
+- **Same intercepted endpoints** — `chat.completions.create()`,
+  `embeddings.create()`, `responses.create()`
 - **Same subclass contract** — `BatchOpenAI` extends the platform's OpenAI client (`AsyncOpenAI` in Python, `OpenAI` in TypeScript), passes `isinstance`/`instanceof` checks, and leaves all non-batched methods (files, batches, models, etc.) untouched
 
 If you change behaviour in one SDK, check whether the other needs the same change.
@@ -146,8 +151,9 @@ Tests are in `python/tests/` and use `pytest` with `pytest-asyncio`. They mock
 the OpenAI SDK's HTTP layer — no real API calls.
 
 ### TypeScript
-No tests yet. When adding tests, follow the same pattern: mock `fetch` or the
-OpenAI client methods, verify the queue → flush → resolve lifecycle.
+Tests are in `typescript/test/` and run with `npm test`. Mock only external
+OpenAI resources and verify both flex submit → poll → resolve and batch queue →
+flush → resolve lifecycles.
 
 ## Key files
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # autobatcher
 
-Drop-in OpenAI client replacement that transparently batches requests via the
-Batch API. Available for [Python](#python) and [TypeScript](#typescript).
+Drop-in OpenAI client replacement that runs text generation through
+Doubleword's flex async-inference polling API by default, with 24-hour batch
+inference available explicitly. Available for [Python](#python) and
+[TypeScript](#typescript).
 
 This library is designed for use with the [Doubleword Inference API](https://docs.doubleword.ai/inference-api/autobatcher).
 Support for OpenAI's batch API or other compatible APIs is best effort — if you experience any issues, please open an issue.
@@ -13,24 +15,17 @@ Support for OpenAI's batch API or other compatible APIs is best effort — if yo
 
 ## Why?
 
-Batch APIs offer significant cost savings — up to 90% with the
-[Doubleword Inference API](https://docs.doubleword.ai) (OpenAI offers 50% off
-with their batch API) — but they require you to restructure your
-code around file uploads and polling. **autobatcher** lets you keep your
-existing async code while getting batch pricing automatically.
+Async and batch inference reduce cost, but normally require applications to
+manage background response IDs, polling, JSONL files, uploads, and result
+matching. **autobatcher** keeps the familiar OpenAI client interface while
+handling those lifecycles internally.
 
 ## Clients
 
-autobatcher exports two clients:
-
-- **`AsyncOpenAI`** — for async inference (up to 50% off with Doubleword).
-  Requests are prioritised ahead of batch but are not real-time. Ideal for
-  agentic workflows, background jobs, and development. **Doubleword only** —
-  OpenAI does not offer an async tier; use `AsyncOpenAI` from the `openai`
-  package instead for real-time OpenAI requests.
-- **`BatchOpenAI`** — for batch inference (up to 90% off with Doubleword, 50%
-  off with OpenAI). Designed for bulk workloads with less time pressure,
-  offering the best price. Works with both Doubleword and OpenAI.
+autobatcher exports `AsyncOpenAI` and `BatchOpenAI` as compatible names for the
+same default behavior. Both use Doubleword flex polling unless
+`completion_window="24h"` / `completionWindow: "24h"` is supplied. Embeddings
+always use 24-hour batches because they do not have a flex tier.
 
 ```python
 # Async inference (Doubleword only)
@@ -40,11 +35,12 @@ client = AsyncOpenAI(
     base_url="https://api.doubleword.ai/v1",
 )
 
-# Batch inference (Doubleword or OpenAI)
+# Explicit 24-hour batch inference
 from autobatcher import BatchOpenAI
 client = BatchOpenAI(
     api_key="sk-...",
     base_url="https://api.doubleword.ai/v1",
+    completion_window="24h",
 )
 
 # Same interface for both — just like the OpenAI SDK
@@ -62,11 +58,12 @@ const client = new AsyncOpenAI({
   baseURL: "https://api.doubleword.ai/v1",
 });
 
-// Batch inference (Doubleword or OpenAI)
+// Explicit 24-hour batch inference
 import { BatchOpenAI } from "autobatcher";
 const client = new BatchOpenAI({
   apiKey: "sk-...",
   baseURL: "https://api.doubleword.ai/v1",
+  completionWindow: "24h",
 });
 
 // Same interface for both — just like the OpenAI SDK
@@ -78,13 +75,14 @@ const response = await client.chat.completions.create({
 
 ## How it works
 
-1. Requests are collected over a configurable time window (default: 10 seconds)
-2. When the window closes or batch size is reached, requests are submitted as a batch
-3. Results are polled and returned to waiting callers as they complete
-4. Your code sees normal response objects — no API changes needed
-
-Different request types (chat completions, embeddings, responses) can be mixed
-in a single batch — each result is parsed with the correct type automatically.
+1. Default chat-completion and Responses calls are submitted immediately to
+   `/v1/responses` with `service_tier: "flex"` and `background: true`.
+2. Autobatcher polls the response ID using short retrieval requests, so the
+   submission connection is not held open during inference.
+3. Chat callers receive a normal `ChatCompletion`; Responses callers receive a
+   normal `Response`.
+4. Embeddings, and all endpoints in explicit 24-hour mode, use the existing
+   queue → JSONL → upload → batch → poll → result lifecycle.
 
 ## Configuration
 
@@ -94,7 +92,8 @@ in a single batch — each result is parsed with the correct type automatically.
 | Base URL | `base_url` | `baseURL` | provider default | API base URL |
 | Batch size | `batch_size` | `batchSize` | `1000` | Submit batch when this many requests are queued |
 | Batch window | `batch_window_seconds` | `batchWindowSeconds` | `10.0` | Submit batch after this many seconds |
-| Poll interval | `poll_interval_seconds` | `pollIntervalSeconds` | `5.0` | How often to poll for batch completion |
+| Poll interval | `poll_interval_seconds` | `pollIntervalSeconds` | `5.0` | How often to poll flex responses or batch completion |
+| Completion window | `completion_window` | `completionWindow` | unset | Set exactly `"24h"` to batch text generation; any other value uses flex |
 | Batch metadata | `batch_metadata` | — | `None` | Optional metadata attached to each batch (Python only) |
 
 ## Supported endpoints
@@ -107,12 +106,12 @@ in a single batch — each result is parsed with the correct type automatically.
 
 All other methods on the client (e.g. `client.models.list()`,
 `client.files.create()`) pass through to the underlying OpenAI client
-unchanged — only the endpoints above are intercepted for batching.
+unchanged — only the endpoints above are intercepted.
 
 ## Serve mode
 
-Both SDKs include a local OpenAI-compatible HTTP proxy that batches incoming
-requests. Useful for transparently batching traffic from tools that support a
+Both SDKs include a local OpenAI-compatible HTTP proxy that routes incoming
+requests. Useful for transparently handling traffic from tools that support a
 custom `base_url` — evaluation frameworks, benchmark runners, or any OpenAI SDK
 consumer.
 
@@ -133,7 +132,7 @@ npx autobatcher serve \
 
 The `--mode` flag controls the inference tier:
 
-- `--mode async` (default) — async inference, higher priority than batch
+- `--mode async` (default) — flex background inference with polling
 - `--mode batch` — batch inference, best price for bulk workloads
 
 Then point any OpenAI-compatible client at the proxy:
@@ -145,11 +144,11 @@ export OPENAI_API_KEY=dummy
 
 Supported proxy routes:
 
-| Route | Upstream batched endpoint |
-|-------|--------------------------|
-| `POST /v1/chat/completions` | `/v1/chat/completions` |
-| `POST /v1/embeddings` | `/v1/embeddings` |
-| `POST /v1/responses` | `/v1/responses` |
+| Route | Default upstream behavior |
+|-------|---------------------------|
+| `POST /v1/chat/completions` | flex Responses polling, converted back to chat |
+| `POST /v1/embeddings` | 24-hour batch |
+| `POST /v1/responses` | flex Responses polling |
 | `GET /health` | local healthcheck |
 
 The proxy emits structured JSON lifecycle events to stdout for log collection.
@@ -158,13 +157,13 @@ shutdown behaviour — see the [Python README](python/README.md) for full detail
 
 ## Limitations
 
-- Not suitable for real-time or interactive use cases due to latency from the
-  collection window and polling cycle.
+- Not suitable for real-time or interactive use cases. Flex work has
+  minutes-scale latency and 24-hour batches may take longer.
 - Streaming is not supported. Requests that would normally stream are forced to
   non-streaming; the proxy can re-wrap results as SSE for consuming clients.
-- `AsyncOpenAI` is Doubleword-only. OpenAI does not offer an async tier — use
-  `BatchOpenAI` for OpenAI batch workloads, or `AsyncOpenAI` from the `openai`
-  package for real-time OpenAI requests.
+- Default flex polling is Doubleword-only. For OpenAI batch workloads, specify
+  a 24-hour completion window; for realtime OpenAI requests, use the upstream
+  OpenAI client directly.
 
 ## Python
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ shutdown behaviour — see the [Python README](python/README.md) for full detail
   minutes-scale latency and 24-hour batches may take longer.
 - Streaming is not supported. Requests that would normally stream are forced to
   non-streaming; the proxy can re-wrap results as SSE for consuming clients.
+- Per-request headers, query parameters, timeouts, and abort signals are
+  supported for flex calls. Batch calls reject transport options because they
+  cannot be represented in Batch API JSONL.
+- HTTP proxy request bodies are limited to 1 MiB.
 - Default flex polling is Doubleword-only. For OpenAI batch workloads, specify
   a 24-hour completion window; for realtime OpenAI requests, use the upstream
   OpenAI client directly.

--- a/fixtures/chat_responses_translation.json
+++ b/fixtures/chat_responses_translation.json
@@ -1,0 +1,182 @@
+[
+  {
+    "name": "function tool conversation",
+    "chat_request": {
+      "model": "test-model",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Weather?"
+        },
+        {
+          "role": "assistant",
+          "content": null,
+          "tool_calls": [
+            {
+              "id": "call-1",
+              "type": "function",
+              "function": {
+                "name": "weather",
+                "arguments": "{\"city\":\"London\"}"
+              }
+            }
+          ]
+        },
+        {
+          "role": "tool",
+          "tool_call_id": "call-1",
+          "content": "Rain"
+        }
+      ],
+      "tools": [
+        {
+          "type": "function",
+          "function": {
+            "name": "weather",
+            "description": "Get weather",
+            "parameters": {
+              "type": "object"
+            },
+            "strict": true
+          }
+        }
+      ],
+      "tool_choice": {
+        "type": "function",
+        "function": {
+          "name": "weather"
+        }
+      },
+      "reasoning_effort": "medium"
+    },
+    "response_request": {
+      "model": "test-model",
+      "input": [
+        {
+          "role": "user",
+          "content": "Weather?"
+        },
+        {
+          "type": "function_call",
+          "call_id": "call-1",
+          "name": "weather",
+          "arguments": "{\"city\":\"London\"}"
+        },
+        {
+          "type": "function_call_output",
+          "call_id": "call-1",
+          "output": "Rain"
+        }
+      ],
+      "tools": [
+        {
+          "type": "function",
+          "name": "weather",
+          "description": "Get weather",
+          "parameters": {
+            "type": "object"
+          },
+          "strict": true
+        }
+      ],
+      "tool_choice": {
+        "type": "function",
+        "name": "weather"
+      },
+      "reasoning": {
+        "effort": "medium"
+      },
+      "stream": false
+    }
+  },
+  {
+    "name": "multimodal user content",
+    "chat_request": {
+      "model": "test-model",
+      "messages": [
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "text",
+              "text": "Describe this image"
+            },
+            {
+              "type": "image_url",
+              "image_url": {
+                "url": "https://example.com/image.png",
+                "detail": "high"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "response_request": {
+      "model": "test-model",
+      "input": [
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "input_text",
+              "text": "Describe this image"
+            },
+            {
+              "type": "input_image",
+              "image_url": "https://example.com/image.png",
+              "detail": "high"
+            }
+          ]
+        }
+      ],
+      "stream": false
+    }
+  },
+  {
+    "name": "structured JSON schema",
+    "chat_request": {
+      "model": "test-model",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Return JSON"
+        }
+      ],
+      "response_format": {
+        "type": "json_schema",
+        "json_schema": {
+          "name": "answer",
+          "description": "Structured answer",
+          "schema": {
+            "type": "object"
+          },
+          "strict": true
+        }
+      },
+      "verbosity": "high"
+    },
+    "response_request": {
+      "model": "test-model",
+      "input": [
+        {
+          "role": "user",
+          "content": "Return JSON"
+        }
+      ],
+      "text": {
+        "format": {
+          "type": "json_schema",
+          "name": "answer",
+          "description": "Structured answer",
+          "schema": {
+            "type": "object"
+          },
+          "strict": true
+        },
+        "verbosity": "high"
+      },
+      "stream": false
+    }
+  }
+]

--- a/python/README.md
+++ b/python/README.md
@@ -272,6 +272,9 @@ generation. Exactly `"24h"` selects the Batch API. Embeddings always use a
   minutes-scale latency and 24-hour batches may take longer.
 - Streaming is not supported. Requests that would normally stream are forced to
   non-streaming; the serve proxy can re-wrap results as SSE for consuming clients.
+- Per-request headers, query parameters, and timeouts are forwarded for flex
+  calls. Batch calls reject transport options because Batch API JSONL cannot
+  represent them.
 - Flex polling is Doubleword-only. OpenAI users must select `"24h"` for batch
   inference or use the upstream OpenAI client for realtime inference.
 - No automatic escalation to realtime if flex or batch inference is delayed.

--- a/python/README.md
+++ b/python/README.md
@@ -1,19 +1,23 @@
 # autobatcher (Python)
 
-Drop-in replacement for `AsyncOpenAI` that transparently batches requests via the [Batch API](https://docs.doubleword.ai/inference-api/autobatcher). Designed for the [Doubleword Inference API](https://docs.doubleword.ai) where batch pricing saves up to 90%. Support for OpenAI's batch API or other compatible APIs is best effort. If you experience any issues, please open an issue.
+Drop-in replacement for `AsyncOpenAI` that uses Doubleword flex background
+inference and polling by default, with explicit 24-hour batch inference. It is
+designed for the [Doubleword Inference API](https://docs.doubleword.ai/inference-api/autobatcher).
 
 ## Why?
 
-Batch APIs offer significant cost savings — up to 90% with the [Doubleword Inference API](https://docs.doubleword.ai) (OpenAI offers 50% off with their 24-hour batch window) — but they require you to restructure your code around file uploads and polling. **autobatcher** lets you keep your existing async code while getting batch pricing automatically.
+Async and batch inference reduce cost, but usually require applications to
+manage background response IDs, polling, JSONL uploads, and result matching.
+**autobatcher** handles those lifecycles behind the familiar OpenAI interface.
 
 ```python
 # Before: regular async calls (full price)
 from openai import AsyncOpenAI
 client = AsyncOpenAI()
 
-# After: batched calls (up to 90% off with Doubleword Inference API)
-from autobatcher import BatchOpenAI
-client = BatchOpenAI(base_url="https://api.doubleword.ai/v1")
+# After: flex calls with background polling
+from autobatcher import AsyncOpenAI
+client = AsyncOpenAI(base_url="https://api.doubleword.ai/v1")
 
 # Same interface, same code
 response = await client.chat.completions.create(
@@ -24,13 +28,14 @@ response = await client.chat.completions.create(
 
 ## How it works
 
-1. Requests are collected over a configurable time window (default: 10 seconds)
-2. When the window closes or batch size is reached, requests are submitted as a batch
-3. Results are polled and returned to waiting callers as they complete
-4. Your code sees normal response objects (`ChatCompletion`, `CreateEmbeddingResponse`, `Response`)
-
-Different request types (chat completions, embeddings, responses) can be mixed
-in a single batch — each result is parsed with the correct type automatically.
+1. Chat-completion and Responses calls are submitted immediately to the
+   Responses API with `service_tier="flex"` and `background=True`.
+2. The returned response ID is polled with separate retrieval requests until
+   completion; no inference connection remains open.
+3. Chat results are converted back to `ChatCompletion`; Responses results stay
+   native `Response` objects.
+4. Embeddings always use 24-hour batches. Passing
+   `completion_window="24h"` puts text generation on the same batch lifecycle.
 
 ## Installation
 
@@ -86,11 +91,11 @@ async def respond(client: BatchOpenAI):
 
 ### Parallel requests
 
-The real power comes when you have many requests:
+Concurrent text requests are submitted independently and queued by Doubleword:
 
 ```python
 async def process_many(prompts: list[str]) -> list[str]:
-    client = BatchOpenAI(batch_size=500, batch_window_seconds=5.0)
+    client = BatchOpenAI()
 
     async def get_response(prompt: str) -> str:
         response = await client.chat.completions.create(
@@ -99,16 +104,16 @@ async def process_many(prompts: list[str]) -> list[str]:
         )
         return response.choices[0].message.content
 
-    # All requests are batched together automatically
+    # All requests use background flex inference and poll independently
     results = await asyncio.gather(*[get_response(p) for p in prompts])
 
     await client.close()
     return results
 ```
 
-### Mixed batching
+### Mixed endpoint routing
 
-Different request types are automatically mixed into the same batch:
+Chat uses flex polling while embeddings continue through a 24-hour batch:
 
 ```python
 async def mixed(client: BatchOpenAI):
@@ -134,7 +139,7 @@ async with BatchOpenAI() as client:
 ## Serve mode
 
 `autobatcher serve` runs a local OpenAI-compatible HTTP proxy. This is useful
-when you want to transparently batch traffic from tools that already support an
+when you want to transparently route traffic from tools that already support an
 OpenAI-style `base_url`, such as evaluation frameworks, SDK consumers, or local
 benchmark runners.
 
@@ -144,10 +149,7 @@ autobatcher serve \
   --api-key "$DOUBLEWORD_API_KEY" \
   --host 127.0.0.1 \
   --port 8080 \
-  --batch-size 1024 \
-  --batch-window 60 \
-  --poll-interval 10 \
-  --completion-window 24h
+  --poll-interval 10
 ```
 
 Then point your OpenAI-compatible client at the proxy:
@@ -163,12 +165,14 @@ to the local OpenAI-compatible proxy.
 
 Supported proxy routes:
 
-| Route | Upstream batched endpoint |
-|-------|----------------------------|
-| `/v1/chat/completions` | `/v1/chat/completions` |
-| `/v1/embeddings` | `/v1/embeddings` |
-| `/v1/responses` | `/v1/responses` |
+| Route | Default upstream behavior |
+|-------|---------------------------|
+| `/v1/chat/completions` | flex Responses polling, converted back to chat |
+| `/v1/embeddings` | 24-hour batch |
+| `/v1/responses` | flex Responses polling |
 | `/health` | local healthcheck |
+
+Pass `--mode batch` to use 24-hour batches for text generation as well.
 
 ### Batch lifecycle events
 
@@ -243,22 +247,16 @@ autobatcher serve --keep-active-batches-on-close
 | `base_url` | `None` | API base URL (for proxies or compatible APIs) |
 | `batch_size` | `1000` | Submit batch when this many requests are queued |
 | `batch_window_seconds` | `10.0` | Submit batch after this many seconds |
-| `poll_interval_seconds` | `5.0` | How often to poll for batch completion |
-| `completion_window` | `"1h"` | Completion deadline (see below) |
+| `poll_interval_seconds` | `5.0` | How often to poll flex responses or batch completion |
+| `completion_window` | `None` | Set to `"24h"` for text-generation batches |
 | `batch_metadata` | `None` | Optional metadata attached to each upstream batch |
 | `cancel_active_batches_on_close` | `False` | Best-effort cancel active upstream batches when closing the client |
 
 ### Completion window
 
-The `completion_window` controls the deadline and pricing tier:
-
-- **`"1h"`** (default) — async inference. Faster turnaround than batch mode,
-  still significantly cheaper than real-time. Supported by the
-  [Doubleword Inference API](https://docs.doubleword.ai) only.
-- **`"24h"`** — batch inference. Maximum cost savings (up to 90% with the
-  [Doubleword Inference API](https://docs.doubleword.ai), 50% with OpenAI).
-  Use for background jobs like evals, data processing, or bulk extraction
-  where latency doesn't matter. This is the only window OpenAI supports.
+An omitted value (and legacy `"1h"`) selects Doubleword flex polling for text
+generation. Exactly `"24h"` selects the Batch API. Embeddings always use a
+24-hour batch, irrespective of this setting.
 
 ## Supported endpoints
 
@@ -270,14 +268,13 @@ The `completion_window` controls the deadline and pricing tier:
 
 ## Limitations
 
-- Not suitable for real-time or interactive use cases — batch mode adds latency
-  from the collection window and polling cycle.
+- Not suitable for real-time or interactive use cases. Flex work has
+  minutes-scale latency and 24-hour batches may take longer.
 - Streaming is not supported. Requests that would normally stream are forced to
   non-streaming; the serve proxy can re-wrap results as SSE for consuming clients.
-- OpenAI only supports `completion_window="24h"`. The `"1h"` window is a
-  Doubleword-specific feature.
-- No automatic escalation to real-time if the completion window elapses — the
-  batch will be marked as expired.
+- Flex polling is Doubleword-only. OpenAI users must select `"24h"` for batch
+  inference or use the upstream OpenAI client for realtime inference.
+- No automatic escalation to realtime if flex or batch inference is delayed.
 
 ## License
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "autobatcher"
 version = "0.10.0"
-description = "Drop-in AsyncOpenAI replacement that transparently batches requests using the batch API"
+description = "Drop-in AsyncOpenAI replacement for flex and batch inference"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"

--- a/python/src/autobatcher/__init__.py
+++ b/python/src/autobatcher/__init__.py
@@ -1,9 +1,9 @@
 """
-Autobatcher: Drop-in AsyncOpenAI replacement that transparently batches requests.
+Autobatcher: Drop-in AsyncOpenAI replacement for flex and batch inference.
 
 Usage:
-    from autobatcher import BatchOpenAI   # 24h batch inference (default)
-    from autobatcher import AsyncOpenAI   # 1h async inference
+    from autobatcher import BatchOpenAI   # flex polling by default
+    from autobatcher import AsyncOpenAI   # equivalent compatibility name
 
     client = BatchOpenAI(api_key="...")
     response = await client.chat.completions.create(

--- a/python/src/autobatcher/__main__.py
+++ b/python/src/autobatcher/__main__.py
@@ -26,13 +26,13 @@ def _parse_batch_metadata(items: list[str] | None) -> dict[str, str]:
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="autobatcher",
-        description="Drop-in OpenAI batch proxy",
+        description="Drop-in OpenAI proxy for flex and batch inference",
     )
     subparsers = parser.add_subparsers(dest="command")
 
     serve = subparsers.add_parser(
         "serve",
-        help="Start an OpenAI-compatible HTTP server that batches requests",
+        help="Start an OpenAI-compatible HTTP server for flex and batch inference",
     )
     serve.add_argument(
         "--base-url",
@@ -95,7 +95,7 @@ def main() -> None:
             batch_size=args.batch_size,
             batch_window_seconds=args.batch_window,
             poll_interval_seconds=args.poll_interval,
-            completion_window="1h" if args.mode == "async" else "24h",
+            completion_window=None if args.mode == "async" else "24h",
             batch_metadata=batch_metadata,
             cancel_active_batches_on_close=not args.keep_active_batches_on_close,
         )

--- a/python/src/autobatcher/_translation.py
+++ b/python/src/autobatcher/_translation.py
@@ -1,0 +1,447 @@
+"""Typed Chat Completions ↔ Responses adapters.
+
+Request types in openai-python are generated ``TypedDict`` definitions, while
+response types are generated Pydantic models.  Keeping the conversion here makes
+that public SDK boundary explicit and leaves transport concerns in ``client.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Literal, cast
+
+from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
+from openai.types.chat.completion_create_params import (
+    CompletionCreateParamsNonStreaming,
+)
+from openai.types.responses import (
+    EasyInputMessageParam,
+    FunctionToolParam,
+    Response,
+    ResponseFunctionToolCall,
+    ResponseFunctionToolCallParam,
+    ResponseInputFileParam,
+    ResponseInputImageParam,
+    ResponseInputItemParam,
+    ResponseInputMessageContentListParam,
+    ResponseInputParam,
+    ResponseInputTextParam,
+    ResponseOutputMessage,
+    ResponseOutputRefusal,
+    ResponseOutputText,
+    ToolChoiceFunctionParam,
+)
+from openai.types.responses.response_create_params import (
+    ResponseCreateParamsNonStreaming,
+    ToolChoice as ResponseToolChoice,
+)
+from openai.types.responses.response_input_param import FunctionCallOutput
+
+
+def _text_content(content: object, *, parameter: str) -> str:
+    """Normalize Chat text or text-part content into one string."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Iterable) and not isinstance(content, (bytes, dict)):
+        text: list[str] = []
+        for part in content:
+            if not isinstance(part, dict) or part.get("type") != "text":
+                raise ValueError(f"{parameter} supports text content only")
+            value = part.get("text")
+            if not isinstance(value, str):
+                raise ValueError(f"{parameter} text content must be a string")
+            text.append(value)
+        return "".join(text)
+    raise ValueError(f"{parameter} content must be text")
+
+
+def _input_content(
+    content: object, *, parameter: str
+) -> str | ResponseInputMessageContentListParam:
+    """Convert Chat message content into official Responses input content."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, Iterable) or isinstance(content, (bytes, dict)):
+        raise ValueError(f"{parameter} content must be text or content parts")
+
+    converted: ResponseInputMessageContentListParam = []
+    for part in content:
+        if not isinstance(part, dict):
+            raise ValueError(f"{parameter} contains an invalid content part")
+        part_type = part.get("type")
+        if part_type == "text":
+            text = part.get("text")
+            if not isinstance(text, str):
+                raise ValueError(f"{parameter} text content must be a string")
+            text_part: ResponseInputTextParam = {"type": "input_text", "text": text}
+            converted.append(text_part)
+        elif part_type == "image_url":
+            image = part.get("image_url")
+            if not isinstance(image, dict) or not isinstance(image.get("url"), str):
+                raise ValueError(f"{parameter} image_url requires a URL")
+            image_part: ResponseInputImageParam = {
+                "type": "input_image",
+                "image_url": image["url"],
+                "detail": image.get("detail", "auto"),
+            }
+            converted.append(image_part)
+        elif part_type == "file":
+            file = part.get("file")
+            if not isinstance(file, dict):
+                raise ValueError(f"{parameter} file content is invalid")
+            converted_file: ResponseInputFileParam = {"type": "input_file"}
+            for key in ("file_data", "file_id", "filename"):
+                value = file.get(key)
+                if value is not None:
+                    converted_file[key] = value
+            if len(converted_file) == 1:
+                raise ValueError(f"{parameter} file content requires file data or an ID")
+            converted.append(converted_file)
+        elif part_type == "input_audio":
+            raise ValueError("input_audio is not supported by flex Responses translation")
+        else:
+            raise ValueError(f"{parameter} contains unsupported content type {part_type!r}")
+    return converted
+
+
+def _assistant_items(message: dict[str, Any]) -> list[ResponseInputItemParam]:
+    """Convert one assistant history message and its tool calls."""
+    if message.get("audio") is not None:
+        raise ValueError("assistant audio is not supported by flex Responses translation")
+    if message.get("function_call") is not None:
+        raise ValueError("deprecated function_call is not supported; use tool_calls")
+    if message.get("name") is not None:
+        raise ValueError("assistant name is not supported by flex Responses translation")
+
+    items: list[ResponseInputItemParam] = []
+    content = message.get("content")
+    if content is not None:
+        if isinstance(content, str):
+            assistant_text = content
+        elif isinstance(content, Iterable) and not isinstance(content, (bytes, dict)):
+            text_parts: list[str] = []
+            for part in content:
+                if not isinstance(part, dict) or part.get("type") not in {"text", "refusal"}:
+                    raise ValueError("assistant content supports text and refusal parts only")
+                value = part.get("text") if part.get("type") == "text" else part.get("refusal")
+                if not isinstance(value, str):
+                    raise ValueError("assistant content part must contain text")
+                text_parts.append(value)
+            assistant_text = "".join(text_parts)
+        else:
+            raise ValueError("assistant content must be text")
+
+        easy_message: EasyInputMessageParam = {
+            "role": "assistant",
+            "content": assistant_text,
+        }
+        items.append(cast(ResponseInputItemParam, easy_message))
+
+    for raw_call in message.get("tool_calls") or []:
+        if not isinstance(raw_call, dict):
+            raise ValueError("tool_calls contains an invalid call")
+        call_type = raw_call.get("type")
+        if call_type != "function":
+            raise ValueError(f"tool_calls contains unsupported type {call_type!r}")
+        call_id = raw_call.get("id")
+        function = raw_call.get("function")
+        if not isinstance(call_id, str) or not call_id:
+            raise ValueError("tool_calls function call requires a non-empty id")
+        if not isinstance(function, dict):
+            raise ValueError("tool_calls function call requires function details")
+        name = function.get("name")
+        arguments = function.get("arguments")
+        if not isinstance(name, str) or not name:
+            raise ValueError("tool_calls function call requires a non-empty name")
+        if not isinstance(arguments, str):
+            raise ValueError("tool_calls function call arguments must be a string")
+        function_call: ResponseFunctionToolCallParam = {
+            "type": "function_call",
+            "call_id": call_id,
+            "name": name,
+            "arguments": arguments,
+        }
+        items.append(cast(ResponseInputItemParam, function_call))
+    return items
+
+
+def _message_to_response_items(
+    message: ChatCompletionMessageParam,
+) -> list[ResponseInputItemParam]:
+    raw = cast(dict[str, Any], message)
+    role = raw.get("role")
+
+    if role == "assistant":
+        return _assistant_items(raw)
+    if role == "tool":
+        call_id = raw.get("tool_call_id")
+        if not isinstance(call_id, str) or not call_id:
+            raise ValueError("tool message requires a non-empty tool_call_id")
+        output = _text_content(raw.get("content"), parameter="tool message")
+        function_output: FunctionCallOutput = {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": output,
+        }
+        return [cast(ResponseInputItemParam, function_output)]
+    if role == "function":
+        raise ValueError("deprecated function messages are not supported; use tool messages")
+    if role not in {"user", "system", "developer"}:
+        raise ValueError(f"unsupported chat message role {role!r}")
+    if raw.get("name") is not None:
+        raise ValueError(f"{role} message name is not supported by flex Responses translation")
+
+    content = _input_content(raw.get("content"), parameter=f"{role} message")
+    easy_message: EasyInputMessageParam = {
+        "role": cast(Literal["user", "system", "developer"], role),
+        "content": content,
+    }
+    return [cast(ResponseInputItemParam, easy_message)]
+
+
+def _messages_to_response_input(
+    messages: Iterable[ChatCompletionMessageParam],
+) -> ResponseInputParam:
+    items: ResponseInputParam = []
+    for message in messages:
+        items.extend(_message_to_response_items(message))
+    return items
+
+
+def _convert_tools(tools: object) -> list[FunctionToolParam]:
+    if not isinstance(tools, Iterable) or isinstance(tools, (str, bytes, dict)):
+        raise ValueError("tools must be a list")
+    converted: list[FunctionToolParam] = []
+    for raw_tool in tools:
+        if not isinstance(raw_tool, dict):
+            raise ValueError("tools contains an invalid definition")
+        tool_type = raw_tool.get("type")
+        if tool_type == "function":
+            function = raw_tool.get("function")
+            if not isinstance(function, dict):
+                raise ValueError("function tool requires function details")
+            name = function.get("name")
+            if not isinstance(name, str) or not name:
+                raise ValueError("function tool requires a non-empty name")
+            parameters = function.get("parameters")
+            if parameters is not None and not isinstance(parameters, dict):
+                raise ValueError("function tool parameters must be an object")
+            strict = function.get("strict", False)
+            if strict is not None and not isinstance(strict, bool):
+                raise ValueError("function tool strict must be a boolean")
+            tool: FunctionToolParam = {
+                "type": "function",
+                "name": name,
+                "parameters": parameters,
+                "strict": strict,
+            }
+            if function.get("description") is not None:
+                tool["description"] = function["description"]
+            converted.append(tool)
+        elif tool_type == "custom":
+            raise ValueError(
+                "custom tools are not supported by the minimum OpenAI SDK schema"
+            )
+        else:
+            raise ValueError(f"tools contains unsupported type {tool_type!r}")
+    return converted
+
+
+def _convert_tool_choice(choice: object) -> ResponseToolChoice:
+    if isinstance(choice, str):
+        if choice not in {"none", "auto", "required"}:
+            raise ValueError(f"tool_choice contains unsupported mode {choice!r}")
+        return choice
+    if not isinstance(choice, dict):
+        raise ValueError("tool_choice is invalid")
+    choice_type = choice.get("type")
+    if choice_type == "function":
+        function = choice.get("function")
+        if not isinstance(function, dict) or not isinstance(function.get("name"), str):
+            raise ValueError("function tool_choice requires a name")
+        converted: ToolChoiceFunctionParam = {
+            "type": "function",
+            "name": function["name"],
+        }
+        return converted
+    if choice_type == "custom":
+        raise ValueError(
+            "custom tool_choice is not supported by the minimum OpenAI SDK schema"
+        )
+    raise ValueError(f"tool_choice contains unsupported type {choice_type!r}")
+
+
+def _convert_response_format(response_format: object) -> dict[str, Any]:
+    if not isinstance(response_format, dict):
+        raise ValueError("response_format is invalid")
+    format_type = response_format.get("type")
+    if format_type in {"text", "json_object"}:
+        return dict(response_format)
+    if format_type == "json_schema":
+        schema = response_format.get("json_schema")
+        if not isinstance(schema, dict):
+            raise ValueError("response_format json_schema requires schema details")
+        return {"type": "json_schema", **schema}
+    raise ValueError(f"response_format contains unsupported type {format_type!r}")
+
+
+def _reject_unsupported(params: dict[str, Any]) -> None:
+    unsupported = {
+        "audio": "audio output",
+        "function_call": "deprecated function_call",
+        "functions": "deprecated functions",
+        "prediction": "prediction",
+        "web_search_options": "web_search_options",
+    }
+    for key, label in unsupported.items():
+        if params.get(key) is not None:
+            raise ValueError(f"{label} is not supported by flex Responses translation")
+
+    modalities = params.get("modalities")
+    if modalities is not None and list(modalities) != ["text"]:
+        raise ValueError("modalities supports text output only in flex Responses translation")
+
+
+def chat_params_to_response(
+    params: CompletionCreateParamsNonStreaming,
+) -> ResponseCreateParamsNonStreaming:
+    """Translate official Chat create parameters into Responses parameters."""
+    source = dict(cast(dict[str, Any], params))
+    _reject_unsupported(source)
+
+    n = source.get("n", 1)
+    if n != 1:
+        raise ValueError("Flex inference supports only n=1 for chat completions")
+    messages = source.get("messages")
+    if messages is None:
+        raise ValueError("Chat completions require messages")
+
+    result: dict[str, Any] = {
+        "model": source.get("model"),
+        "input": _messages_to_response_input(messages),
+        "stream": False,
+    }
+
+    shared_fields = (
+        "metadata",
+        "moderation",
+        "parallel_tool_calls",
+        "prompt_cache_key",
+        "prompt_cache_options",
+        "prompt_cache_retention",
+        "safety_identifier",
+        "store",
+        "temperature",
+        "top_logprobs",
+        "top_p",
+        "user",
+    )
+    for key in shared_fields:
+        if source.get(key) is not None:
+            result[key] = source[key]
+
+    max_tokens = source.get("max_completion_tokens")
+    if max_tokens is None:
+        max_tokens = source.get("max_tokens")
+    if max_tokens is not None:
+        result["max_output_tokens"] = max_tokens
+
+    response_format = source.get("response_format")
+    verbosity = source.get("verbosity")
+    if response_format is not None or verbosity is not None:
+        text: dict[str, Any] = {}
+        if response_format is not None:
+            text["format"] = _convert_response_format(response_format)
+        if verbosity is not None:
+            text["verbosity"] = verbosity
+        result["text"] = text
+
+    reasoning_effort = source.get("reasoning_effort")
+    if reasoning_effort is not None:
+        result["reasoning"] = {"effort": reasoning_effort}
+
+    if source.get("logprobs") is True:
+        result["include"] = ["message.output_text.logprobs"]
+    if source.get("tools") is not None:
+        result["tools"] = _convert_tools(source["tools"])
+    if source.get("tool_choice") is not None:
+        result["tool_choice"] = _convert_tool_choice(source["tool_choice"])
+
+    # Doubleword accepts these Chat-compatible extensions on /responses even
+    # though openai-python does not currently declare them on Responses.create.
+    for key in ("frequency_penalty", "presence_penalty", "seed", "logit_bias", "stop"):
+        if source.get(key) is not None:
+            result[key] = source[key]
+
+    return cast(ResponseCreateParamsNonStreaming, result)
+
+
+def response_to_chat_completion(response: Response) -> ChatCompletion:
+    """Adapt a completed official Responses object into a ChatCompletion."""
+    text_parts: list[str] = []
+    refusals: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+
+    for item in response.output:
+        if isinstance(item, ResponseOutputMessage):
+            for part in item.content:
+                if isinstance(part, ResponseOutputText):
+                    text_parts.append(part.text)
+                elif isinstance(part, ResponseOutputRefusal):
+                    refusals.append(part.refusal)
+        elif isinstance(item, ResponseFunctionToolCall):
+            if not item.call_id:
+                raise ValueError("Responses function_call requires a non-empty call_id")
+            if not item.name:
+                raise ValueError("Responses function_call requires a non-empty name")
+            tool_calls.append(
+                {
+                    "id": item.call_id,
+                    "type": "function",
+                    "function": {
+                        "name": item.name,
+                        "arguments": item.arguments,
+                    },
+                }
+            )
+
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": "".join(text_parts) if text_parts else None,
+        "refusal": "".join(refusals) if refusals else None,
+    }
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    usage: dict[str, Any] | None = None
+    if response.usage is not None:
+        usage = {
+            "prompt_tokens": response.usage.input_tokens,
+            "completion_tokens": response.usage.output_tokens,
+            "total_tokens": response.usage.total_tokens,
+            "prompt_tokens_details": {
+                "cached_tokens": response.usage.input_tokens_details.cached_tokens,
+            },
+            "completion_tokens_details": {
+                "reasoning_tokens": response.usage.output_tokens_details.reasoning_tokens,
+            },
+        }
+
+    return ChatCompletion.model_validate(
+        {
+            "id": response.id,
+            "object": "chat.completion",
+            "created": int(response.created_at),
+            "model": response.model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": message,
+                    "logprobs": None,
+                    "finish_reason": "tool_calls" if tool_calls else "stop",
+                }
+            ],
+            "usage": usage,
+            "service_tier": response.service_tier,
+        }
+    )

--- a/python/src/autobatcher/_translation.py
+++ b/python/src/autobatcher/_translation.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Literal, cast
 
-from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionMessageParam,
+    ChatCompletionTokenLogprob,
+)
+from openai.types.chat.chat_completion_token_logprob import TopLogprob
 from openai.types.chat.completion_create_params import (
     CompletionCreateParamsNonStreaming,
 )
@@ -381,12 +386,29 @@ def response_to_chat_completion(response: Response) -> ChatCompletion:
     text_parts: list[str] = []
     refusals: list[str] = []
     tool_calls: list[dict[str, Any]] = []
+    content_logprobs: list[ChatCompletionTokenLogprob] = []
 
     for item in response.output:
         if isinstance(item, ResponseOutputMessage):
             for part in item.content:
                 if isinstance(part, ResponseOutputText):
                     text_parts.append(part.text)
+                    for logprob in part.logprobs or []:
+                        content_logprobs.append(
+                            ChatCompletionTokenLogprob(
+                                token=logprob.token,
+                                bytes=logprob.bytes,
+                                logprob=logprob.logprob,
+                                top_logprobs=[
+                                    TopLogprob(
+                                        token=top.token,
+                                        bytes=top.bytes,
+                                        logprob=top.logprob,
+                                    )
+                                    for top in logprob.top_logprobs
+                                ],
+                            )
+                        )
                 elif isinstance(part, ResponseOutputRefusal):
                     refusals.append(part.refusal)
         elif isinstance(item, ResponseFunctionToolCall):
@@ -437,7 +459,11 @@ def response_to_chat_completion(response: Response) -> ChatCompletion:
                 {
                     "index": 0,
                     "message": message,
-                    "logprobs": None,
+                    "logprobs": (
+                        {"content": content_logprobs, "refusal": None}
+                        if content_logprobs
+                        else None
+                    ),
                     "finish_reason": "tool_calls" if tool_calls else "stop",
                 }
             ],

--- a/python/src/autobatcher/client.py
+++ b/python/src/autobatcher/client.py
@@ -28,6 +28,11 @@ from openai.types import CreateEmbeddingResponse
 from openai.types.responses import Response
 from openai import NotGiven
 from openai._types import Omit
+from openai.types.chat.completion_create_params import (
+    CompletionCreateParamsNonStreaming,
+)
+
+from ._translation import chat_params_to_response, response_to_chat_completion
 
 # Sentinel types the openai SDK uses for "not provided" parameters.
 # Both are non-JSON-serializable and must be stripped before batching.
@@ -111,32 +116,9 @@ def _parse_retry_after(headers: httpx.Headers | dict[str, str], default: float =
 
 
 def _chat_params_to_response(params: dict[str, Any]) -> dict[str, Any]:
-    """Translate a Chat Completions request into a Responses API request."""
-    translated = _clean_params(params)
-
-    n = translated.pop("n", 1)
-    if n != 1:
-        raise ValueError("Flex inference supports only n=1 for chat completions")
-
-    messages = translated.pop("messages", None)
-    if messages is None:
-        raise ValueError("Chat completions require messages")
-    translated["input"] = messages
-
-    max_output_tokens = translated.pop("max_completion_tokens", None)
-    legacy_max_tokens = translated.pop("max_tokens", None)
-    if max_output_tokens is not None:
-        translated["max_output_tokens"] = max_output_tokens
-    elif legacy_max_tokens is not None:
-        translated["max_output_tokens"] = legacy_max_tokens
-
-    response_format = translated.pop("response_format", None)
-    if response_format is not None:
-        translated["text"] = {"format": response_format}
-
-    translated.pop("stream_options", None)
-    translated["stream"] = False
-    return translated
+    """Compatibility wrapper around the official-type request translator."""
+    cleaned = cast(CompletionCreateParamsNonStreaming, _clean_params(params))
+    return cast(dict[str, Any], chat_params_to_response(cleaned))
 
 
 def _response_create_kwargs(params: dict[str, Any]) -> dict[str, Any]:
@@ -149,82 +131,8 @@ def _response_create_kwargs(params: dict[str, Any]) -> dict[str, Any]:
 
 
 def _response_to_chat_completion(response: Response) -> ChatCompletion:
-    """Convert a completed Responses API object into a ChatCompletion."""
-    response_data = response.model_dump(mode="json")
-    text_parts: list[str] = []
-    tool_calls: list[dict[str, Any]] = []
-
-    for item in response_data.get("output", []):
-        item_type = item.get("type")
-        if item_type == "message":
-            content = item.get("content")
-            if isinstance(content, str):
-                text_parts.append(content)
-            elif isinstance(content, list):
-                for part in content:
-                    if isinstance(part, dict) and part.get("type") == "output_text":
-                        text = part.get("text")
-                        if isinstance(text, str):
-                            text_parts.append(text)
-            for call in item.get("tool_calls") or []:
-                function = call.get("function") or {}
-                tool_calls.append(
-                    {
-                        "id": call.get("id") or call.get("call_id"),
-                        "type": "function",
-                        "function": {
-                            "name": function.get("name") or call.get("name"),
-                            "arguments": function.get("arguments")
-                            or call.get("arguments")
-                            or "{}",
-                        },
-                    }
-                )
-        elif item_type == "function_call":
-            tool_calls.append(
-                {
-                    "id": item.get("call_id") or item.get("id"),
-                    "type": "function",
-                    "function": {
-                        "name": item.get("name"),
-                        "arguments": item.get("arguments") or "{}",
-                    },
-                }
-            )
-
-    message: dict[str, Any] = {
-        "role": "assistant",
-        "content": "".join(text_parts) if text_parts else None,
-    }
-    if tool_calls:
-        message["tool_calls"] = tool_calls
-
-    usage = response_data.get("usage")
-    chat_usage = None
-    if isinstance(usage, dict):
-        chat_usage = {
-            "prompt_tokens": usage.get("input_tokens", 0),
-            "completion_tokens": usage.get("output_tokens", 0),
-            "total_tokens": usage.get("total_tokens", 0),
-        }
-
-    return ChatCompletion.model_validate(
-        {
-            "id": response.id,
-            "object": "chat.completion",
-            "created": int(response.created_at),
-            "model": response.model,
-            "choices": [
-                {
-                    "index": 0,
-                    "message": message,
-                    "finish_reason": "tool_calls" if tool_calls else "stop",
-                }
-            ],
-            "usage": chat_usage,
-            "service_tier": "flex",
-        }
-    )
+    """Compatibility wrapper around the official-model response translator."""
+    return response_to_chat_completion(response)
 
 
 BatchEndpoint = Literal[

--- a/python/src/autobatcher/client.py
+++ b/python/src/autobatcher/client.py
@@ -101,6 +101,19 @@ def _clean_params(params: dict[str, Any]) -> dict[str, Any]:
     return cleaned
 
 
+def _split_transport_options(
+    params: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Separate SDK request options from the JSON request body."""
+    body = dict(params)
+    options: dict[str, Any] = {}
+    for key in _TRANSPORT_KEYS:
+        value = body.pop(key, None)
+        if value is not None and not isinstance(value, _SENTINEL_TYPES):
+            options[key] = value
+    return _clean_params(body), options
+
+
 def _parse_retry_after(headers: httpx.Headers | dict[str, str], default: float = 60.0) -> float:
     """Extract retry delay in seconds from a Retry-After header.
 
@@ -214,6 +227,10 @@ class _ChatCompletionsRawResponse:
     def __init__(self, completions: _BatchedChatCompletions) -> None:
         self._completions = completions
 
+    def __getattr__(self, name: str) -> Any:
+        upstream = self._completions._client._chat_api.completions.with_raw_response
+        return getattr(upstream, name)
+
     async def create(self, **kwargs: Any) -> _RawResponseWrapper[ChatCompletion]:
         result = await self._completions.create(**kwargs)
         return _RawResponseWrapper(result)
@@ -224,6 +241,10 @@ class _EmbeddingsRawResponse:
 
     def __init__(self, embeddings: _BatchedEmbeddings) -> None:
         self._embeddings = embeddings
+
+    def __getattr__(self, name: str) -> Any:
+        upstream = self._embeddings._client._embeddings_api.with_raw_response
+        return getattr(upstream, name)
 
     async def create(
         self, **kwargs: Any
@@ -237,6 +258,10 @@ class _ResponsesRawResponse:
 
     def __init__(self, responses: _BatchedResponses) -> None:
         self._responses = responses
+
+    def __getattr__(self, name: str) -> Any:
+        upstream = self._responses._client._responses_api.with_raw_response
+        return getattr(upstream, name)
 
     async def create(self, **kwargs: Any) -> _RawResponseWrapper[Response]:
         result = await self._responses.create(**kwargs)
@@ -276,6 +301,9 @@ class _BatchedChatCompletions:
     def __init__(self, client: BatchOpenAI):
         self._client = client
 
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client._chat_api.completions, name)
+
     @property
     def with_raw_response(self) -> _ChatCompletionsRawResponse:
         """Mimic the openai SDK's ``with_raw_response`` accessor.
@@ -306,7 +334,11 @@ class _BatchedChat:
     """Proxy for chat namespace."""
 
     def __init__(self, client: BatchOpenAI):
+        self._client = client
         self.completions = _BatchedChatCompletions(client)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client._chat_api, name)
 
 
 class _BatchedEmbeddings:
@@ -314,6 +346,9 @@ class _BatchedEmbeddings:
 
     def __init__(self, client: BatchOpenAI):
         self._client = client
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client._embeddings_api, name)
 
     @property
     def with_raw_response(self) -> _EmbeddingsRawResponse:
@@ -347,6 +382,10 @@ class _BatchedResponses:
 
     def __init__(self, client: BatchOpenAI):
         self._client = client
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate non-create operations to the official Responses resource."""
+        return getattr(self._client._responses_api, name)
 
     @property
     def with_raw_response(self) -> _ResponsesRawResponse:
@@ -473,9 +512,13 @@ class BatchOpenAI(AsyncOpenAI):
         # Active batches being polled
         self._active_batches: list[_ActiveBatch] = []
         self._poller_task: asyncio.Task[None] | None = None
+        self._active_flex_tasks: set[asyncio.Task[Any]] = set()
+        self._flex_response_ids: dict[asyncio.Task[Any], str] = {}
 
-        # Keep the inherited Responses resource for flex submission and polling
-        # before shadowing it with the OpenAI-compatible intercepted proxy.
+        # Keep inherited resources so every operation other than create can be
+        # delegated unchanged after the intercepted proxies shadow them.
+        self._chat_api = self.chat
+        self._embeddings_api = self.embeddings
         self._responses_api = self.responses
 
         # Override intercepted namespaces with routing proxies.
@@ -516,10 +559,27 @@ class BatchOpenAI(AsyncOpenAI):
             raise RuntimeError("BatchOpenAI is closed")
 
         if endpoint != "/v1/embeddings" and self._completion_window != "24h":
-            return await self._execute_flex(
-                endpoint=endpoint,
-                result_type=result_type,
-                params=params,
+            task = asyncio.create_task(
+                self._execute_flex(
+                    endpoint=endpoint,
+                    result_type=result_type,
+                    params=params,
+                ),
+                name=f"flex_poll_{endpoint}",
+            )
+            self._active_flex_tasks.add(task)
+            try:
+                return await task
+            finally:
+                self._active_flex_tasks.discard(task)
+                self._flex_response_ids.pop(task, None)
+
+        _, transport_options = _split_transport_options(params)
+        if transport_options:
+            names = ", ".join(sorted(transport_options))
+            raise ValueError(
+                f"Per-request transport options ({names}) cannot be represented "
+                "by the Batch API"
             )
 
         loop = asyncio.get_running_loop()
@@ -563,10 +623,11 @@ class BatchOpenAI(AsyncOpenAI):
         params: dict[str, Any],
     ) -> V:
         """Submit one background flex response and poll it to a terminal state."""
+        body_params, transport_options = _split_transport_options(params)
         if endpoint == "/v1/chat/completions":
-            submit_params = _chat_params_to_response(params)
+            submit_params = _chat_params_to_response(body_params)
         elif endpoint == "/v1/responses":
-            submit_params = _clean_params(params)
+            submit_params = body_params
             submit_params.pop("stream_options", None)
             submit_params["stream"] = False
         else:
@@ -575,29 +636,54 @@ class BatchOpenAI(AsyncOpenAI):
         submit_params["service_tier"] = "flex"
         submit_params["background"] = True
 
-        response = await self._responses_api.create(
-            **_response_create_kwargs(submit_params)
-        )
-        if not isinstance(response, Response):
-            raise RuntimeError("Flex submission returned an unexpected streaming response")
-
-        while response.status in {"queued", "in_progress"}:
-            await asyncio.sleep(self._poll_interval_seconds)
-            retrieved = await self._responses_api.retrieve(response.id)
-            if not isinstance(retrieved, Response):
-                raise RuntimeError("Flex polling returned an unexpected streaming response")
-            response = retrieved
-
-        if response.status != "completed":
-            detail = response.error.message if response.error else "no error details"
-            raise RuntimeError(
-                f"Flex response {response.id} reached terminal status "
-                f"{response.status}: {detail}"
+        response_id: str | None = None
+        current_task = asyncio.current_task()
+        try:
+            response = await self._responses_api.create(
+                **_response_create_kwargs(submit_params),
+                **transport_options,
             )
+            if not isinstance(response, Response):
+                raise RuntimeError(
+                    "Flex submission returned an unexpected streaming response"
+                )
+            response_id = response.id
+            if current_task is not None:
+                self._flex_response_ids[current_task] = response_id
 
-        if endpoint == "/v1/chat/completions":
-            return cast(V, _response_to_chat_completion(response))
-        return cast(V, response)
+            while response.status in {"queued", "in_progress"}:
+                await asyncio.sleep(self._poll_interval_seconds)
+                retrieved = await self._responses_api.retrieve(
+                    response.id, **transport_options
+                )
+                if not isinstance(retrieved, Response):
+                    raise RuntimeError(
+                        "Flex polling returned an unexpected streaming response"
+                    )
+                response = retrieved
+
+            if response.status != "completed":
+                detail = response.error.message if response.error else "no error details"
+                raise RuntimeError(
+                    f"Flex response {response.id} reached terminal status "
+                    f"{response.status}: {detail}"
+                )
+
+            if endpoint == "/v1/chat/completions":
+                return cast(V, _response_to_chat_completion(response))
+            return cast(V, response)
+        except asyncio.CancelledError:
+            if response_id is not None:
+                try:
+                    await asyncio.shield(self._responses_api.cancel(response_id))
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to cancel flex response {}: {}", response_id, exc
+                    )
+            raise
+        finally:
+            if current_task is not None:
+                self._flex_response_ids.pop(current_task, None)
 
     async def _window_timer(self, endpoint: str) -> None:
         """Timer that triggers batch submission after the window elapses."""
@@ -635,8 +721,10 @@ class BatchOpenAI(AsyncOpenAI):
         # Create JSONL content — each line uses the request's own endpoint
         lines = []
         for req in requests:
-            # Clean params for JSONL and force non-streaming
-            body = {**_clean_params(req.params), "stream": False}
+            body = _clean_params(req.params)
+            body.pop("stream_options", None)
+            if req.endpoint != "/v1/embeddings":
+                body["stream"] = False
             line = {
                 "custom_id": req.custom_id,
                 "method": "POST",
@@ -1004,6 +1092,19 @@ class BatchOpenAI(AsyncOpenAI):
             self._poller_task.cancel()
             await asyncio.gather(self._poller_task, return_exceptions=True)
         self._poller_task = None
+
+        current_task = asyncio.current_task()
+        active_flex = [
+            task
+            for task in self._active_flex_tasks
+            if not task.done() and task is not current_task
+        ]
+        for task in active_flex:
+            task.cancel()
+        if active_flex:
+            await asyncio.gather(*active_flex, return_exceptions=True)
+        self._active_flex_tasks.clear()
+        self._flex_response_ids.clear()
 
         for endpoint, requests in self._pending.items():
             for req in requests:

--- a/python/src/autobatcher/client.py
+++ b/python/src/autobatcher/client.py
@@ -1,8 +1,8 @@
 """
-BatchOpenAI: A drop-in replacement for AsyncOpenAI that uses the batch API.
+BatchOpenAI: A drop-in AsyncOpenAI replacement for flex and batch inference.
 
-Collects requests over a time window or until a size threshold, submits them
-as a batch, polls for results, and returns them to waiting callers.
+Text generation uses Doubleword background Responses polling by default.
+Embeddings and explicit 24-hour requests use the Batch API.
 
 Subclasses AsyncOpenAI so it passes isinstance checks and provides full
 access to non-batched endpoints (models, files, etc.) out of the box.
@@ -17,7 +17,7 @@ import uuid
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Generic, Literal, Protocol, TypeVar
+from typing import Any, Generic, Literal, Protocol, TypeVar, cast
 
 import httpx
 import openai
@@ -36,6 +36,32 @@ _SENTINEL_TYPES = (NotGiven, Omit)
 # Keys that are transport-level client options, not request body fields.
 _TRANSPORT_KEYS = frozenset({
     "extra_headers", "extra_query", "timeout",
+})
+
+# Stable openai-python Responses.create keyword arguments. Provider extensions
+# and newer request fields travel through extra_body so the declared SDK method
+# signature cannot reject otherwise valid Doubleword parameters.
+_RESPONSE_CREATE_KEYS = frozenset({
+    "background",
+    "include",
+    "input",
+    "instructions",
+    "max_output_tokens",
+    "metadata",
+    "model",
+    "parallel_tool_calls",
+    "previous_response_id",
+    "reasoning",
+    "service_tier",
+    "store",
+    "stream",
+    "temperature",
+    "text",
+    "tool_choice",
+    "tools",
+    "top_p",
+    "truncation",
+    "user",
 })
 
 
@@ -82,6 +108,123 @@ def _parse_retry_after(headers: httpx.Headers | dict[str, str], default: float =
         except (ValueError, TypeError):
             pass
     return default
+
+
+def _chat_params_to_response(params: dict[str, Any]) -> dict[str, Any]:
+    """Translate a Chat Completions request into a Responses API request."""
+    translated = _clean_params(params)
+
+    n = translated.pop("n", 1)
+    if n != 1:
+        raise ValueError("Flex inference supports only n=1 for chat completions")
+
+    messages = translated.pop("messages", None)
+    if messages is None:
+        raise ValueError("Chat completions require messages")
+    translated["input"] = messages
+
+    max_output_tokens = translated.pop("max_completion_tokens", None)
+    legacy_max_tokens = translated.pop("max_tokens", None)
+    if max_output_tokens is not None:
+        translated["max_output_tokens"] = max_output_tokens
+    elif legacy_max_tokens is not None:
+        translated["max_output_tokens"] = legacy_max_tokens
+
+    response_format = translated.pop("response_format", None)
+    if response_format is not None:
+        translated["text"] = {"format": response_format}
+
+    translated.pop("stream_options", None)
+    translated["stream"] = False
+    return translated
+
+
+def _response_create_kwargs(params: dict[str, Any]) -> dict[str, Any]:
+    """Split SDK-declared Responses fields from provider body extensions."""
+    declared = {k: v for k, v in params.items() if k in _RESPONSE_CREATE_KEYS}
+    extensions = {k: v for k, v in params.items() if k not in _RESPONSE_CREATE_KEYS}
+    if extensions:
+        declared["extra_body"] = extensions
+    return declared
+
+
+def _response_to_chat_completion(response: Response) -> ChatCompletion:
+    """Convert a completed Responses API object into a ChatCompletion."""
+    response_data = response.model_dump(mode="json")
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+
+    for item in response_data.get("output", []):
+        item_type = item.get("type")
+        if item_type == "message":
+            content = item.get("content")
+            if isinstance(content, str):
+                text_parts.append(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "output_text":
+                        text = part.get("text")
+                        if isinstance(text, str):
+                            text_parts.append(text)
+            for call in item.get("tool_calls") or []:
+                function = call.get("function") or {}
+                tool_calls.append(
+                    {
+                        "id": call.get("id") or call.get("call_id"),
+                        "type": "function",
+                        "function": {
+                            "name": function.get("name") or call.get("name"),
+                            "arguments": function.get("arguments")
+                            or call.get("arguments")
+                            or "{}",
+                        },
+                    }
+                )
+        elif item_type == "function_call":
+            tool_calls.append(
+                {
+                    "id": item.get("call_id") or item.get("id"),
+                    "type": "function",
+                    "function": {
+                        "name": item.get("name"),
+                        "arguments": item.get("arguments") or "{}",
+                    },
+                }
+            )
+
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": "".join(text_parts) if text_parts else None,
+    }
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    usage = response_data.get("usage")
+    chat_usage = None
+    if isinstance(usage, dict):
+        chat_usage = {
+            "prompt_tokens": usage.get("input_tokens", 0),
+            "completion_tokens": usage.get("output_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+        }
+
+    return ChatCompletion.model_validate(
+        {
+            "id": response.id,
+            "object": "chat.completion",
+            "created": int(response.created_at),
+            "model": response.model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": message,
+                    "finish_reason": "tool_calls" if tool_calls else "stop",
+                }
+            ],
+            "usage": chat_usage,
+            "service_tier": "flex",
+        }
+    )
 
 
 BatchEndpoint = Literal[
@@ -206,6 +349,7 @@ class _ActiveBatch:
     created_at: float
     models: tuple[str, ...] = ()
     metadata: dict[str, str] = field(default_factory=dict)
+    completion_window: str = "24h"
     result_types: dict[str, type[_Validatable]] = field(default_factory=dict)  # custom_id -> result type
     last_offset: int = 0  # Track offset for partial result streaming
     last_status: str | None = None
@@ -281,7 +425,7 @@ class _BatchedEmbeddings:
         """
         Create embeddings. The request is queued and batched.
 
-        Returns when the batch completes and results are available.
+        Returns when the embedding batch completes and results are available.
         """
         return await self._client._enqueue_request(
             endpoint="/v1/embeddings",
@@ -291,7 +435,7 @@ class _BatchedEmbeddings:
 
 
 class _BatchedResponses:
-    """Proxy for responses API that batches requests."""
+    """Proxy for Responses calls routed through flex or batch inference."""
 
     def __init__(self, client: BatchOpenAI):
         self._client = client
@@ -312,9 +456,9 @@ class _BatchedResponses:
         **kwargs: Any,
     ) -> Response:
         """
-        Create a response. The request is queued and batched.
+        Create a response using flex polling or an explicit 24-hour batch.
 
-        Returns when the batch completes and results are available.
+        Returns when flex polling or the explicit batch completes.
         """
         params: dict[str, Any] = {"model": model, **kwargs}
         if input is not None:
@@ -332,10 +476,10 @@ class _BatchedResponses:
 
 class BatchOpenAI(AsyncOpenAI):
     """
-    Drop-in replacement for AsyncOpenAI that uses the batch API.
+    Drop-in replacement for AsyncOpenAI using flex polling by default.
 
-    Requests are collected and submitted as batches based on size and time
-    thresholds. Results are polled and returned to waiting callers.
+    Text requests submit to Doubleword's background Responses API and poll by
+    response ID. Embeddings and explicit 24-hour requests use batch inference.
 
     Subclasses AsyncOpenAI, so it passes isinstance checks and provides
     full access to non-batched endpoints (models, files, etc.).
@@ -354,7 +498,7 @@ class BatchOpenAI(AsyncOpenAI):
             messages=[{"role": "user", "content": "Hello!"}],
         )
 
-        # Embeddings are also batched
+        # Embeddings always use 24-hour batches
         embeddings = await client.embeddings.create(
             model="text-embedding-3-small",
             input="Hello world",
@@ -369,7 +513,7 @@ class BatchOpenAI(AsyncOpenAI):
         batch_size: int = 1000,
         batch_window_seconds: float = 10.0,
         poll_interval_seconds: float = 5.0,
-        completion_window: str = "24h",
+        completion_window: str | None = None,
         batch_metadata: dict[str, str] | None = None,
         batch_event_handler: BatchEventHandler | None = None,
         cancel_active_batches_on_close: bool = False,
@@ -383,8 +527,8 @@ class BatchOpenAI(AsyncOpenAI):
             base_url: Base URL for the API (e.g., "https://api.doubleword.ai/v1")
             batch_size: Submit batch when this many requests are queued
             batch_window_seconds: Submit batch after this many seconds, even if size not reached
-            poll_interval_seconds: How often to poll for batch completion
-            completion_window: Batch completion window passed through to the upstream API
+            poll_interval_seconds: How often to poll flex responses or batches
+            completion_window: Set to "24h" for batch inference; otherwise use flex polling
             batch_metadata: Optional metadata attached to upstream batches
             batch_event_handler: Optional callback for structured batch lifecycle events
             cancel_active_batches_on_close: Best-effort cancel for in-flight upstream batches on close()
@@ -422,7 +566,11 @@ class BatchOpenAI(AsyncOpenAI):
         self._active_batches: list[_ActiveBatch] = []
         self._poller_task: asyncio.Task[None] | None = None
 
-        # Override namespaces with batched proxies.
+        # Keep the inherited Responses resource for flex submission and polling
+        # before shadowing it with the OpenAI-compatible intercepted proxy.
+        self._responses_api = self.responses
+
+        # Override intercepted namespaces with routing proxies.
         # Write to __dict__ directly to shadow the parent's cached_property
         # descriptors without triggering type-checker read-only errors.
         self.__dict__["chat"] = _BatchedChat(self)
@@ -459,6 +607,13 @@ class BatchOpenAI(AsyncOpenAI):
         if self._closed:
             raise RuntimeError("BatchOpenAI is closed")
 
+        if endpoint != "/v1/embeddings" and self._completion_window != "24h":
+            return await self._execute_flex(
+                endpoint=endpoint,
+                result_type=result_type,
+                params=params,
+            )
+
         loop = asyncio.get_running_loop()
         future: asyncio.Future[V] = loop.create_future()
 
@@ -491,6 +646,50 @@ class BatchOpenAI(AsyncOpenAI):
                 await self._submit_batch(endpoint)
 
         return await future
+
+    async def _execute_flex(
+        self,
+        *,
+        endpoint: BatchEndpoint,
+        result_type: type[V],
+        params: dict[str, Any],
+    ) -> V:
+        """Submit one background flex response and poll it to a terminal state."""
+        if endpoint == "/v1/chat/completions":
+            submit_params = _chat_params_to_response(params)
+        elif endpoint == "/v1/responses":
+            submit_params = _clean_params(params)
+            submit_params.pop("stream_options", None)
+            submit_params["stream"] = False
+        else:
+            raise ValueError(f"Flex inference is not supported for {endpoint}")
+
+        submit_params["service_tier"] = "flex"
+        submit_params["background"] = True
+
+        response = await self._responses_api.create(
+            **_response_create_kwargs(submit_params)
+        )
+        if not isinstance(response, Response):
+            raise RuntimeError("Flex submission returned an unexpected streaming response")
+
+        while response.status in {"queued", "in_progress"}:
+            await asyncio.sleep(self._poll_interval_seconds)
+            retrieved = await self._responses_api.retrieve(response.id)
+            if not isinstance(retrieved, Response):
+                raise RuntimeError("Flex polling returned an unexpected streaming response")
+            response = retrieved
+
+        if response.status != "completed":
+            detail = response.error.message if response.error else "no error details"
+            raise RuntimeError(
+                f"Flex response {response.id} reached terminal status "
+                f"{response.status}: {detail}"
+            )
+
+        if endpoint == "/v1/chat/completions":
+            return cast(V, _response_to_chat_completion(response))
+        return cast(V, response)
 
     async def _window_timer(self, endpoint: str) -> None:
         """Timer that triggers batch submission after the window elapses."""
@@ -541,6 +740,15 @@ class BatchOpenAI(AsyncOpenAI):
 
         # Use the first request's endpoint for the top-level batches.create() call
         top_level_endpoint = requests[0].endpoint
+        batch_completion_window = "24h"
+        if top_level_endpoint != "/v1/embeddings" and self._completion_window != "24h":
+            error = RuntimeError(
+                "Text generation uses the Batch API only when completion_window='24h'"
+            )
+            for req in requests:
+                if not req.future.done():
+                    req.future.set_exception(error)
+            return
         models = tuple(sorted({
             model for req in requests for model in [req.params.get("model")] if isinstance(model, str)
         }))
@@ -567,14 +775,12 @@ class BatchOpenAI(AsyncOpenAI):
                     file_obj.seek(0)
             logger.debug("Uploaded batch file: {}", file_response.id)
 
-            # Create the batch (retry on rate limit).
-            # The openai SDK types `completion_window` narrowly, but some
-            # OpenAI-compatible providers accept additional values. Pass the
-            # caller-provided string through unchanged.
+            # Create a 24-hour batch. Flex text inference never reaches this path,
+            # and embeddings have no flex tier.
             batch_create_kwargs: dict[str, Any] = {
                 "input_file_id": file_response.id,
                 "endpoint": top_level_endpoint,
-                "completion_window": self._completion_window,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+                "completion_window": batch_completion_window,
             }
             if self._batch_metadata:
                 batch_create_kwargs["metadata"] = self._batch_metadata
@@ -605,6 +811,7 @@ class BatchOpenAI(AsyncOpenAI):
                 created_at=time.time(),
                 models=models,
                 metadata=dict(self._batch_metadata),
+                completion_window=batch_completion_window,
                 result_types={req.custom_id: req.result_type for req in requests},
             )
             self._active_batches.append(active_batch)
@@ -617,7 +824,7 @@ class BatchOpenAI(AsyncOpenAI):
                 error_file_id=batch_response.error_file_id,
                 request_count=len(requests),
                 models=list(models),
-                completion_window=self._completion_window,
+                completion_window=batch_completion_window,
                 metadata=dict(self._batch_metadata),
             )
 
@@ -635,7 +842,7 @@ class BatchOpenAI(AsyncOpenAI):
                 endpoint=top_level_endpoint,
                 request_count=len(requests),
                 models=list(models),
-                completion_window=self._completion_window,
+                completion_window=batch_completion_window,
                 metadata=dict(self._batch_metadata),
                 error=str(e),
             )
@@ -693,7 +900,7 @@ class BatchOpenAI(AsyncOpenAI):
                             },
                             status=status.status,
                             models=list(batch.models),
-                            completion_window=self._completion_window,
+                            completion_window=batch.completion_window,
                             metadata=dict(batch.metadata),
                             elapsed_seconds=round(time.time() - batch.created_at, 3),
                         )
@@ -720,7 +927,7 @@ class BatchOpenAI(AsyncOpenAI):
                                 "total": total_count,
                             },
                             models=list(batch.models),
-                            completion_window=self._completion_window,
+                            completion_window=batch.completion_window,
                             metadata=dict(batch.metadata),
                             elapsed_seconds=round(time.time() - batch.created_at, 3),
                         )
@@ -746,7 +953,7 @@ class BatchOpenAI(AsyncOpenAI):
                             },
                             status=status.status,
                             models=list(batch.models),
-                            completion_window=self._completion_window,
+                            completion_window=batch.completion_window,
                             metadata=dict(batch.metadata),
                             elapsed_seconds=round(time.time() - batch.created_at, 3),
                         )
@@ -911,7 +1118,7 @@ class BatchOpenAI(AsyncOpenAI):
                     error_file_id=batch.error_file_id or None,
                     request_count=batch.request_count,
                     models=list(batch.models),
-                    completion_window=self._completion_window,
+                    completion_window=batch.completion_window,
                     metadata=dict(batch.metadata),
                 )
                 try:
@@ -946,7 +1153,7 @@ class BatchOpenAI(AsyncOpenAI):
 
 
 class AsyncOpenAI(BatchOpenAI):
-    """BatchOpenAI variant defaulting to 1h completion window (async inference)."""
+    """Compatibility alias for the default flex-inference client."""
 
-    def __init__(self, *, completion_window: str = "1h", **kwargs: Any):
+    def __init__(self, *, completion_window: str | None = None, **kwargs: Any):
         super().__init__(completion_window=completion_window, **kwargs)

--- a/python/src/autobatcher/serve.py
+++ b/python/src/autobatcher/serve.py
@@ -5,9 +5,9 @@ Usage:
     autobatcher serve --base-url https://api.doubleword.ai/v1 --api-key sk-... --port 8080
 
 Clients talk to http://localhost:8080/v1/chat/completions (etc.) and requests
-are transparently batched via the batch API. Streaming requests are accepted —
-the batch is made non-streaming upstream and the complete response is re-wrapped
-as an SSE stream for the caller.
+use flex background polling by default. Embeddings and explicit 24-hour mode use
+the Batch API. Streaming requests are accepted — upstream work is non-streaming
+and the complete response is re-wrapped as an SSE stream for the caller.
 """
 
 from __future__ import annotations
@@ -182,7 +182,7 @@ def run_server(
     batch_size: int = 1000,
     batch_window_seconds: float = 10.0,
     poll_interval_seconds: float = 5.0,
-    completion_window: str = "24h",
+    completion_window: str | None = None,
     batch_metadata: dict[str, str] | None = None,
     cancel_active_batches_on_close: bool = True,
 ) -> None:
@@ -193,7 +193,7 @@ def run_server(
         batch_size=batch_size,
         batch_window_seconds=batch_window_seconds,
         poll_interval_seconds=poll_interval_seconds,
-        completion_window=completion_window,  # type: ignore[arg-type]
+        completion_window=completion_window,
         batch_metadata=batch_metadata,
         batch_event_handler=_stdout_batch_event_handler,
         cancel_active_batches_on_close=cancel_active_batches_on_close,

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -80,7 +80,10 @@ def make_response_api_result(model: str = "gpt-4o", output_text: str = "Hello!")
             "input_tokens": 10,
             "output_tokens": 5,
             "total_tokens": 15,
-            "input_tokens_details": {"cached_tokens": 0},
+            "input_tokens_details": {
+                "cached_tokens": 0,
+                "cache_write_tokens": 0,
+            },
             "output_tokens_details": {"reasoning_tokens": 0},
         },
         "parallel_tool_calls": True,
@@ -197,6 +200,7 @@ def client(mock_openai: AsyncMock) -> BatchOpenAI:
     c._window_tasks = {}
     c._active_batches = []
     c._poller_task = None
+    c._responses_api = AsyncMock()
     # Mock the internal httpx client that AsyncOpenAI.close() would call.
     # Since we skip __init__ via __new__, this isn't set up automatically.
     c._client = AsyncMock()

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -200,6 +200,11 @@ def client(mock_openai: AsyncMock) -> BatchOpenAI:
     c._window_tasks = {}
     c._active_batches = []
     c._poller_task = None
+    c._active_flex_tasks = set()
+    c._flex_response_ids = {}
+    c._chat_api = AsyncMock()
+    c._chat_api.completions = AsyncMock()
+    c._embeddings_api = AsyncMock()
     c._responses_api = AsyncMock()
     # Mock the internal httpx client that AsyncOpenAI.close() would call.
     # Since we skip __init__ via __new__, this isn't set up automatically.

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -26,7 +26,7 @@ def test_cli_mode_async_default(monkeypatch) -> None:
 
     cli.main()
 
-    assert captured["completion_window"] == "1h"
+    assert captured["completion_window"] is None
 
 
 def test_cli_mode_batch(monkeypatch) -> None:

--- a/python/tests/test_embeddings.py
+++ b/python/tests/test_embeddings.py
@@ -36,6 +36,53 @@ def _httpx_response(
 
 
 class TestEmbeddingsJSONL:
+    async def test_default_mode_embeddings_force_24h_batch(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Regression: embeddings have no flex tier and must use 24h batches."""
+        client._completion_window = None
+        loop = asyncio.get_event_loop()
+        fut = loop.create_future()
+        req = _PendingRequest(
+            custom_id="emb-window",
+            endpoint="/v1/embeddings",
+            result_type=CreateEmbeddingResponse,
+            params={"model": "text-embedding-3-small", "input": "hello"},
+            future=fut,
+        )
+        client._pending[req.endpoint] = [req]
+
+        await client._submit_batch(req.endpoint)
+
+        assert client.batches.create.await_args.kwargs["completion_window"] == "24h"
+
+    async def test_embeddings_never_enter_flex_executor(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Regression: default mode must retain the embedding batch queue."""
+        client._completion_window = None
+        client._batch_size = 1
+        client._execute_flex = AsyncMock(
+            side_effect=AssertionError("embeddings entered flex inference")
+        )
+
+        task = asyncio.create_task(
+            client.embeddings.create(
+                model="text-embedding-3-small",
+                input="hello",
+            )
+        )
+        await asyncio.sleep(0)
+
+        client._execute_flex.assert_not_awaited()
+        client.files.create.assert_awaited_once()
+
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        if client._poller_task and not client._poller_task.done():
+            client._poller_task.cancel()
+            await asyncio.gather(client._poller_task, return_exceptions=True)
+
     async def test_jsonl_has_embeddings_url(self, client: BatchOpenAI) -> None:
         """Embedding requests should produce JSONL lines with url=/v1/embeddings."""
         loop = asyncio.get_event_loop()

--- a/python/tests/test_embeddings.py
+++ b/python/tests/test_embeddings.py
@@ -105,6 +105,8 @@ class TestEmbeddingsJSONL:
         assert line["method"] == "POST"
         assert line["body"]["model"] == "text-embedding-3-small"
         assert line["body"]["input"] == "hello world"
+        assert "stream" not in line["body"]
+        assert "stream_options" not in line["body"]
 
     async def test_batches_create_uses_embeddings_endpoint(
         self, client: BatchOpenAI

--- a/python/tests/test_flex_polling.py
+++ b/python/tests/test_flex_polling.py
@@ -1,0 +1,232 @@
+"""Tests for Doubleword flex background submission and polling."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from openai.types.chat import ChatCompletion
+from openai.types.responses import Response
+
+import autobatcher.client as client_module
+from autobatcher import AsyncOpenAI as AutobatcherAsyncOpenAI
+from autobatcher.client import BatchOpenAI
+from tests.conftest import make_response_api_result
+
+
+def _response(
+    *,
+    status: str = "completed",
+    output_text: str = "Hello!",
+    response_id: str = "resp-test123",
+) -> Response:
+    body = make_response_api_result(output_text=output_text)
+    body["id"] = response_id
+    body["status"] = status
+    if status in {"queued", "in_progress"}:
+        body["output"] = []
+    return Response.model_validate(body)
+
+
+class TestFlexDefaults:
+    async def test_both_clients_default_to_flex_mode(self) -> None:
+        """Regression: neither public client should batch text by default."""
+        clients = [
+            BatchOpenAI(api_key="sk-test"),
+            AutobatcherAsyncOpenAI(api_key="sk-test"),
+        ]
+        try:
+            assert [client._completion_window for client in clients] == [None, None]
+        finally:
+            for client in clients:
+                await client.close()
+
+    async def test_non_24h_chat_routes_around_batch_queue(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Regression: flex chat must not upload JSONL or create a batch."""
+        expected = ChatCompletion.model_validate(
+            {
+                "id": "chatcmpl-flex",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "test-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "hello"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        )
+        execute_flex = AsyncMock(return_value=expected)
+        client._execute_flex = execute_flex  # type: ignore[attr-defined]
+        client._completion_window = "1h"
+        client._batch_size = 1
+        client._submit_batch = AsyncMock(
+            side_effect=AssertionError("flex chat entered the batch queue")
+        )
+
+        result = await client._enqueue_request(
+            endpoint="/v1/chat/completions",
+            result_type=ChatCompletion,
+            params={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+        assert result is expected
+        execute_flex.assert_awaited_once()
+        client.files.create.assert_not_awaited()
+
+
+class TestFlexPolling:
+    async def test_doubleword_response_extensions_use_extra_body(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Regression: Doubleword-only fields must pass the SDK method boundary."""
+        completed = _response(status="completed")
+        client._responses_api.create = AsyncMock(return_value=completed)
+
+        await client._execute_flex(
+            endpoint="/v1/responses",
+            result_type=Response,
+            params={
+                "model": "test-model",
+                "input": "hello",
+                "frequency_penalty": 0.2,
+                "reasoning_effort": "medium",
+                "stop": ["DONE"],
+            },
+        )
+
+        assert client._responses_api.create.await_args.kwargs["extra_body"] == {
+            "frequency_penalty": 0.2,
+            "reasoning_effort": "medium",
+            "stop": ["DONE"],
+        }
+
+    async def test_responses_submit_in_background_and_poll_to_completion(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Regression: inference waits through GET polling, not an open POST."""
+        queued = _response(status="queued")
+        in_progress = _response(status="in_progress")
+        completed = _response(status="completed", output_text="done")
+        client._poll_interval_seconds = 0
+        client._responses_api.create = AsyncMock(return_value=queued)
+        client._responses_api.retrieve = AsyncMock(
+            side_effect=[in_progress, completed]
+        )
+
+        result = await client._execute_flex(
+            endpoint="/v1/responses",
+            result_type=Response,
+            params={"model": "test-model", "input": "hello", "stream": True},
+        )
+
+        assert result is completed
+        assert client._responses_api.create.await_args.kwargs == {
+            "model": "test-model",
+            "input": "hello",
+            "stream": False,
+            "service_tier": "flex",
+            "background": True,
+        }
+        assert [
+            call.args for call in client._responses_api.retrieve.await_args_list
+        ] == [("resp-test123",), ("resp-test123",)]
+        client.files.create.assert_not_awaited()
+
+    @pytest.mark.parametrize("status", ["failed", "cancelled", "incomplete"])
+    async def test_terminal_non_completed_response_raises(
+        self, client: BatchOpenAI, status: str
+    ) -> None:
+        """Regression: terminal failures must not be returned as successes."""
+        terminal = _response(status=status, response_id="resp-terminal")
+        client._responses_api.create = AsyncMock(return_value=terminal)
+
+        with pytest.raises(
+            RuntimeError, match=rf"resp-terminal.*{status}|{status}.*resp-terminal"
+        ):
+            await client._execute_flex(
+                endpoint="/v1/responses",
+                result_type=Response,
+                params={"model": "test-model", "input": "hello"},
+            )
+
+
+class TestChatAdapters:
+    def test_chat_params_translate_to_responses_fields(self) -> None:
+        """Regression: chat-only field names must not leak into Responses."""
+        translated = client_module._chat_params_to_response(
+            {
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_completion_tokens": 321,
+                "response_format": {"type": "json_object"},
+                "temperature": 0.4,
+                "stream": True,
+            }
+        )
+
+        assert translated == {
+            "model": "test-model",
+            "input": [{"role": "user", "content": "hello"}],
+            "max_output_tokens": 321,
+            "text": {"format": {"type": "json_object"}},
+            "temperature": 0.4,
+            "stream": False,
+        }
+
+    def test_chat_params_reject_multiple_choices(self) -> None:
+        """Regression: one Responses result cannot masquerade as n chat choices."""
+        with pytest.raises(ValueError, match="n=1"):
+            client_module._chat_params_to_response(
+                {
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "n": 2,
+                }
+            )
+
+    def test_completed_response_converts_to_chat_completion(self) -> None:
+        """Regression: flex chat callers still receive ChatCompletion models."""
+        response = _response(status="completed", output_text="converted")
+
+        result = client_module._response_to_chat_completion(response)
+
+        assert isinstance(result, ChatCompletion)
+        assert result.id == "resp-test123"
+        assert result.object == "chat.completion"
+        assert result.choices[0].message.content == "converted"
+        assert result.choices[0].finish_reason == "stop"
+        assert result.usage is not None
+        assert result.usage.prompt_tokens == 10
+        assert result.usage.completion_tokens == 5
+
+    def test_function_call_converts_to_chat_tool_call(self) -> None:
+        """Regression: Responses function calls must survive chat adaptation."""
+        body = make_response_api_result(output_text="")
+        body["output"] = [
+            {
+                "type": "function_call",
+                "id": "fc-test",
+                "call_id": "call-test",
+                "name": "get_weather",
+                "arguments": '{"city":"London"}',
+                "status": "completed",
+            }
+        ]
+        response = Response.model_validate(body)
+
+        result = client_module._response_to_chat_completion(response)
+
+        tool_calls = result.choices[0].message.tool_calls
+        assert tool_calls is not None
+        assert tool_calls[0].id == "call-test"
+        assert tool_calls[0].function.name == "get_weather"
+        assert tool_calls[0].function.arguments == '{"city":"London"}'
+        assert result.choices[0].finish_reason == "tool_calls"

--- a/python/tests/test_flex_polling.py
+++ b/python/tests/test_flex_polling.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -12,6 +14,11 @@ import autobatcher.client as client_module
 from autobatcher import AsyncOpenAI as AutobatcherAsyncOpenAI
 from autobatcher.client import BatchOpenAI
 from tests.conftest import make_response_api_result
+
+
+TRANSLATION_CASES = json.loads(
+    (Path(__file__).parents[2] / "fixtures/chat_responses_translation.json").read_text()
+)
 
 
 def _response(
@@ -159,6 +166,17 @@ class TestFlexPolling:
 
 
 class TestChatAdapters:
+    @pytest.mark.parametrize(
+        "case",
+        TRANSLATION_CASES,
+        ids=[case["name"] for case in TRANSLATION_CASES],
+    )
+    def test_chat_requests_match_shared_response_fixtures(self, case: dict) -> None:
+        """Regression: Python and TypeScript must emit the same typed wire shape."""
+        assert client_module._chat_params_to_response(case["chat_request"]) == case[
+            "response_request"
+        ]
+
     def test_chat_params_translate_to_responses_fields(self) -> None:
         """Regression: chat-only field names must not leak into Responses."""
         translated = client_module._chat_params_to_response(
@@ -189,6 +207,22 @@ class TestChatAdapters:
                     "model": "test-model",
                     "messages": [{"role": "user", "content": "hello"}],
                     "n": 2,
+                }
+            )
+
+    def test_chat_params_reject_custom_tools_outside_minimum_sdk_schema(self) -> None:
+        """Regression: transforms must stay inside the declared OpenAI 2.x types."""
+        with pytest.raises(ValueError, match="custom.*tool|tool.*custom"):
+            client_module._chat_params_to_response(
+                {
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "tools": [
+                        {
+                            "type": "custom",
+                            "custom": {"name": "shell", "format": {"type": "text"}},
+                        }
+                    ],
                 }
             )
 
@@ -230,3 +264,52 @@ class TestChatAdapters:
         assert tool_calls[0].function.name == "get_weather"
         assert tool_calls[0].function.arguments == '{"city":"London"}'
         assert result.choices[0].finish_reason == "tool_calls"
+
+    def test_refusal_service_tier_and_usage_details_are_preserved(self) -> None:
+        """Regression: typed response fields must not disappear during adaptation."""
+        body = make_response_api_result(output_text="")
+        body["service_tier"] = "priority"
+        body["output"] = [
+            {
+                "type": "message",
+                "id": "msg-refusal",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {"type": "refusal", "refusal": "I cannot help with that."}
+                ],
+            }
+        ]
+        body["usage"]["input_tokens_details"]["cached_tokens"] = 7
+        body["usage"]["output_tokens_details"]["reasoning_tokens"] = 3
+        response = Response.model_validate(body)
+
+        result = client_module._response_to_chat_completion(response)
+
+        message = result.choices[0].message
+        assert message.content is None
+        assert message.refusal == "I cannot help with that."
+        assert result.service_tier == "priority"
+        assert result.usage is not None
+        assert result.usage.prompt_tokens_details is not None
+        assert result.usage.prompt_tokens_details.cached_tokens == 7
+        assert result.usage.completion_tokens_details is not None
+        assert result.usage.completion_tokens_details.reasoning_tokens == 3
+
+    def test_function_call_requires_a_real_call_id(self) -> None:
+        """Regression: malformed calls must not become placeholder Chat tool IDs."""
+        body = make_response_api_result(output_text="")
+        body["output"] = [
+            {
+                "type": "function_call",
+                "id": "fc-test",
+                "call_id": "",
+                "name": "get_weather",
+                "arguments": "{}",
+                "status": "completed",
+            }
+        ]
+        response = Response.model_validate(body)
+
+        with pytest.raises(ValueError, match="call_id"):
+            client_module._response_to_chat_completion(response)

--- a/python/tests/test_flex_polling.py
+++ b/python/tests/test_flex_polling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -146,6 +147,56 @@ class TestFlexPolling:
             call.args for call in client._responses_api.retrieve.await_args_list
         ] == [("resp-test123",), ("resp-test123",)]
         client.files.create.assert_not_awaited()
+
+    async def test_flex_forwards_per_request_transport_options(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Headers, query parameters, and timeout must reach create and polls."""
+        queued = _response(status="queued", response_id="resp-options")
+        completed = _response(status="completed", response_id="resp-options")
+        client._poll_interval_seconds = 0
+        client._responses_api.create = AsyncMock(return_value=queued)
+        client._responses_api.retrieve = AsyncMock(return_value=completed)
+
+        await client._execute_flex(
+            endpoint="/v1/responses",
+            result_type=Response,
+            params={
+                "model": "test-model",
+                "input": "hello",
+                "extra_headers": {"X-Route": "tenant-a"},
+                "extra_query": {"region": "uk"},
+                "timeout": 12.5,
+            },
+        )
+
+        for awaited in (
+            client._responses_api.create.await_args,
+            client._responses_api.retrieve.await_args,
+        ):
+            assert awaited.kwargs["extra_headers"] == {"X-Route": "tenant-a"}
+            assert awaited.kwargs["extra_query"] == {"region": "uk"}
+            assert awaited.kwargs["timeout"] == 12.5
+
+    async def test_batch_mode_rejects_unusable_transport_options(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Batch JSONL cannot silently discard per-request transport controls."""
+        client._completion_window = "24h"
+
+        with pytest.raises(ValueError, match="transport options.*Batch|Batch.*transport"):
+            await asyncio.wait_for(
+                client._enqueue_request(
+                    endpoint="/v1/chat/completions",
+                    result_type=ChatCompletion,
+                    params={
+                        "model": "test-model",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "timeout": 2.0,
+                    },
+                ),
+                timeout=0.02,
+            )
 
     @pytest.mark.parametrize("status", ["failed", "cancelled", "incomplete"])
     async def test_terminal_non_completed_response_raises(
@@ -295,6 +346,36 @@ class TestChatAdapters:
         assert result.usage.prompt_tokens_details.cached_tokens == 7
         assert result.usage.completion_tokens_details is not None
         assert result.usage.completion_tokens_details.reasoning_tokens == 3
+
+    def test_output_logprobs_are_preserved_in_chat_completion(self) -> None:
+        """A requested Responses logprob payload must survive chat adaptation."""
+        body = make_response_api_result(output_text="Hello")
+        body["output"][0]["content"][0]["logprobs"] = [
+            {
+                "token": "Hello",
+                "bytes": [72, 101, 108, 108, 111],
+                "logprob": -0.25,
+                "top_logprobs": [
+                    {
+                        "token": "Hi",
+                        "bytes": [72, 105],
+                        "logprob": -1.5,
+                    }
+                ],
+            }
+        ]
+        response = Response.model_validate(body)
+
+        result = client_module._response_to_chat_completion(response)
+
+        logprobs = result.choices[0].logprobs
+        assert logprobs is not None
+        assert logprobs.content is not None
+        assert logprobs.content[0].token == "Hello"
+        assert logprobs.content[0].bytes == [72, 101, 108, 108, 111]
+        assert logprobs.content[0].logprob == -0.25
+        assert logprobs.content[0].top_logprobs[0].token == "Hi"
+        assert logprobs.content[0].top_logprobs[0].logprob == -1.5
 
     def test_function_call_requires_a_real_call_id(self) -> None:
         """Regression: malformed calls must not become placeholder Chat tool IDs."""

--- a/python/tests/test_lifecycle.py
+++ b/python/tests/test_lifecycle.py
@@ -6,8 +6,10 @@ import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
+from openai.types.responses import Response
 
 from autobatcher.client import BatchOpenAI, _ActiveBatch
+from tests.conftest import make_response_api_result
 import time
 
 
@@ -39,6 +41,39 @@ class TestClose:
         assert not client._window_tasks
         assert client._poller_task is None
         await client.close()  # Should not raise
+
+    async def test_close_cancels_active_flex_poll_and_upstream_response(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Closing must not leave a local poller or paid background response alive."""
+        body = make_response_api_result(output_text="")
+        body["id"] = "resp-active"
+        body["status"] = "queued"
+        body["output"] = []
+        queued = Response.model_validate(body)
+        client._completion_window = None
+        client._poll_interval_seconds = 60
+        client._responses_api.create = AsyncMock(return_value=queued)
+        client._responses_api.cancel = AsyncMock(return_value=queued)
+
+        request = asyncio.create_task(
+            client.responses.create(model="test-model", input="hello")
+        )
+        for _ in range(10):
+            if client._responses_api.create.await_count:
+                break
+            await asyncio.sleep(0)
+        assert client._responses_api.create.await_count == 1
+
+        try:
+            await client.close()
+
+            assert request.cancelled()
+            client._responses_api.cancel.assert_awaited_once_with("resp-active")
+        finally:
+            if not request.done():
+                request.cancel()
+                await asyncio.gather(request, return_exceptions=True)
 
     async def test_close_cancels_active_upstream_batches_when_enabled(
         self, client: BatchOpenAI

--- a/python/tests/test_subclass.py
+++ b/python/tests/test_subclass.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
 from openai import AsyncOpenAI
 
 from autobatcher.client import BatchOpenAI
@@ -28,3 +32,48 @@ class TestSubclass:
         assert isinstance(client.chat, _BatchedChat)
         assert isinstance(client.embeddings, _BatchedEmbeddings)
         assert isinstance(client.responses, _BatchedResponses)
+
+    @pytest.mark.asyncio
+    async def test_non_create_response_methods_delegate_to_openai_resource(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Replacing responses.create must not hide retrieve/cancel/delete."""
+        expected = object()
+        client._responses_api.retrieve = AsyncMock(return_value=expected)
+
+        result = await client.responses.retrieve("resp-existing")
+
+        assert result is expected
+        client._responses_api.retrieve.assert_awaited_once_with("resp-existing")
+
+    @pytest.mark.asyncio
+    async def test_non_create_chat_completion_methods_delegate(
+        self, client: BatchOpenAI
+    ) -> None:
+        """Stored completion operations must remain available after interception."""
+        expected = object()
+        retrieve = AsyncMock(return_value=expected)
+        client._chat_api = SimpleNamespace(
+            completions=SimpleNamespace(retrieve=retrieve)
+        )
+
+        result = await client.chat.completions.retrieve("chatcmpl-existing")
+
+        assert result is expected
+        retrieve.assert_awaited_once_with("chatcmpl-existing")
+
+    @pytest.mark.asyncio
+    async def test_raw_non_create_response_methods_delegate(
+        self, client: BatchOpenAI
+    ) -> None:
+        """The raw-response facade must only override create()."""
+        expected = object()
+        retrieve = AsyncMock(return_value=expected)
+        client._responses_api.with_raw_response = SimpleNamespace(
+            retrieve=retrieve
+        )
+
+        result = await client.responses.with_raw_response.retrieve("resp-existing")
+
+        assert result is expected
+        retrieve.assert_awaited_once_with("resp-existing")

--- a/python/tests/test_submit_batch.py
+++ b/python/tests/test_submit_batch.py
@@ -108,19 +108,21 @@ class TestSubmitBatch:
         assert call_kwargs["endpoint"] == "/v1/chat/completions"
         assert call_kwargs["completion_window"] == "24h"
 
-    async def test_batches_create_passes_through_arbitrary_completion_window(
+    async def test_non_24h_text_does_not_create_batch(
         self, client: BatchOpenAI
     ) -> None:
-        """Nonstandard completion_window values should be passed through unchanged."""
+        """Only an explicit 24h window may reach text batch creation."""
         file_obj = make_file_object("file-xyz")
         client.files.create.return_value = file_obj
         client._completion_window = "72h"
 
-        _add_pending(client, 1)
+        requests = _add_pending(client, 1)
         await client._submit_batch(EP)
 
-        call_kwargs = client.batches.create.call_args.kwargs
-        assert call_kwargs["completion_window"] == "72h"
+        client.files.create.assert_not_awaited()
+        client.batches.create.assert_not_awaited()
+        with pytest.raises(RuntimeError, match="only when completion_window='24h'"):
+            requests[0].future.result()
 
     async def test_batches_create_passes_metadata(
         self, client: BatchOpenAI

--- a/python/tests/test_submit_batch.py
+++ b/python/tests/test_submit_batch.py
@@ -78,6 +78,8 @@ class TestSubmitBatch:
             assert parsed["url"] == "/v1/chat/completions"
             assert "model" in parsed["body"]
             assert "messages" in parsed["body"]
+            assert parsed["body"]["stream"] is False
+            assert "stream_options" not in parsed["body"]
 
     async def test_files_create_called_with_batch_purpose(
         self, client: BatchOpenAI

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,15 +1,14 @@
 # autobatcher (TypeScript)
 
 Drop-in [`OpenAI`](https://www.npmjs.com/package/openai) client that
-transparently batches requests via the
-[Batch API](https://docs.doubleword.ai/inference-api/autobatcher). Designed for
-the [Doubleword Inference API](https://docs.doubleword.ai) where batch pricing
-saves up to 90%.
+uses Doubleword flex background inference and polling by default, with explicit
+24-hour batch inference. It is designed for the
+[Doubleword Inference API](https://docs.doubleword.ai/inference-api/autobatcher).
 
 `BatchOpenAI` is a subclass of `OpenAI` — it passes `instanceof` checks and
-works anywhere the standard client is accepted. The only difference:
-`chat.completions.create()` and `embeddings.create()` calls are collected into
-a queue and submitted as batch jobs instead of making individual HTTP requests.
+works anywhere the standard client is accepted. Chat and Responses calls submit
+immediately with `service_tier: "flex"` and `background: true`, then poll by
+response ID. Embeddings always use 24-hour batches.
 
 ## Installation
 
@@ -48,14 +47,24 @@ const response = await client.embeddings.create({
 console.log(response.data[0].embedding.slice(0, 5));
 ```
 
+### Responses API
+
+```typescript
+const response = await client.responses.create({
+  model: "Qwen/Qwen3.5-35B-A3B-FP8",
+  input: "Explain quantum computing in one sentence.",
+});
+console.log(response.output_text);
+```
+
 ### Parallel requests
 
-The real power comes when you have many requests:
+Concurrent text requests are submitted independently and queued by Doubleword:
 
 ```typescript
 const prompts = ["What is 1+1?", "What is 2+2?", "What is 3+3?"];
 
-// All requests are batched together automatically
+// All requests use background flex inference and poll independently
 const results = await Promise.all(
   prompts.map((prompt) =>
     client.chat.completions.create({
@@ -74,8 +83,8 @@ await client.close();
 
 ## Serve mode
 
-`autobatcher serve` runs a local OpenAI-compatible HTTP proxy that batches
-incoming requests. Useful for transparently batching traffic from tools that
+`autobatcher serve` runs a local OpenAI-compatible HTTP proxy that routes
+incoming requests. Useful for transparently handling traffic from tools that
 support a custom `baseURL` — evaluation frameworks, benchmark runners, or any
 OpenAI SDK consumer.
 
@@ -83,10 +92,7 @@ OpenAI SDK consumer.
 npx autobatcher serve \
   --base-url https://api.doubleword.ai/v1 \
   --api-key "$DOUBLEWORD_API_KEY" \
-  --port 8080 \
-  --batch-size 1024 \
-  --batch-window 60 \
-  --completion-window 24h
+  --port 8080
 ```
 
 Then point any OpenAI-compatible client at the proxy:
@@ -101,12 +107,14 @@ client uses a dummy key because it is only talking to the local proxy.
 
 Supported proxy routes:
 
-| Route | Upstream batched endpoint |
-|-------|--------------------------|
-| `POST /v1/chat/completions` | `/v1/chat/completions` |
-| `POST /v1/embeddings` | `/v1/embeddings` |
-| `POST /v1/responses` | `/v1/responses` |
+| Route | Default upstream behavior |
+|-------|---------------------------|
+| `POST /v1/chat/completions` | flex Responses polling, converted back to chat |
+| `POST /v1/embeddings` | 24-hour batch |
+| `POST /v1/responses` | flex Responses polling |
 | `GET /health` | local healthcheck |
+
+Pass `--mode batch` to use 24-hour batches for text generation as well.
 
 The proxy emits structured JSON lifecycle events to stdout for log collection:
 
@@ -125,8 +133,7 @@ const { server, close } = serve({
   baseURL: "https://api.doubleword.ai/v1",
   apiKey: "sk-...",
   port: 8080,
-  batchSize: 1024,
-  completionWindow: "1h",
+  pollIntervalSeconds: 5,
 });
 
 // Later: gracefully shut down
@@ -141,20 +148,14 @@ await close();
 | `baseURL` | provider default | API base URL |
 | `batchSize` | `1000` | Submit batch when this many requests are queued |
 | `batchWindowSeconds` | `10` | Submit batch after this many seconds |
-| `pollIntervalSeconds` | `5` | How often to poll for batch completion |
-| `completionWindow` | `"1h"` | Completion deadline (see below) |
+| `pollIntervalSeconds` | `5` | How often to poll flex responses or batch completion |
+| `completionWindow` | unset | Set to `"24h"` for text-generation batches |
 
 ### Completion window
 
-The `completionWindow` controls the deadline and pricing tier:
-
-- **`"1h"`** (default) — async inference. Faster turnaround than batch mode,
-  still significantly cheaper than real-time. Supported by the
-  [Doubleword Inference API](https://docs.doubleword.ai) only.
-- **`"24h"`** — batch inference. Maximum cost savings (up to 90% with the
-  [Doubleword Inference API](https://docs.doubleword.ai), 50% with OpenAI).
-  Use for background jobs like evals, data processing, or bulk extraction
-  where latency doesn't matter. This is the only window OpenAI supports.
+An omitted value (and legacy `"1h"`) selects Doubleword flex polling for text
+generation. Exactly `"24h"` selects the Batch API. Embeddings always use a
+24-hour batch, irrespective of this setting.
 
 ## Supported endpoints
 
@@ -162,23 +163,21 @@ The `completionWindow` controls the deadline and pricing tier:
 |----------|-------------|
 | `client.chat.completions.create()` | `ChatCompletion` |
 | `client.embeddings.create()` | `CreateEmbeddingResponse` |
+| `client.responses.create()` | `Response` |
 
 All other methods on the client (e.g. `client.models.list()`,
 `client.files.create()`) pass through to the underlying OpenAI client
-unchanged — only the endpoints above are intercepted for batching.
+unchanged — only the endpoints above are intercepted.
 
 ## Limitations
 
-- Not suitable for real-time or interactive use cases — batch mode adds latency
-  from the collection window and polling cycle.
+- Not suitable for real-time or interactive use cases. Flex work has
+  minutes-scale latency and 24-hour batches may take longer.
 - Streaming is not supported. Requests with `stream: true` will have streaming
   stripped and results returned as a complete response.
-- OpenAI only supports `completionWindow: "24h"`. The `"1h"` window is a
-  Doubleword-specific feature.
-- No automatic escalation to real-time if the completion window elapses — the
-  batch will be marked as expired.
-- Responses API batching (`client.responses.create()`) is available via the
-  serve proxy but not yet via the `BatchOpenAI` class directly.
+- Flex polling is Doubleword-only. OpenAI users must select `"24h"` for batch
+  inference or use the upstream OpenAI client for realtime inference.
+- No automatic escalation to realtime if flex or batch inference is delayed.
 
 ## License
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -175,6 +175,10 @@ unchanged — only the endpoints above are intercepted.
   minutes-scale latency and 24-hour batches may take longer.
 - Streaming is not supported. Requests with `stream: true` will have streaming
   stripped and results returned as a complete response.
+- Per-request headers, query parameters, timeouts, and abort signals are
+  forwarded for flex calls. Batch calls reject transport options because Batch
+  API JSONL cannot represent them.
+- The bundled HTTP proxy limits request bodies to 1 MiB.
 - Flex polling is Doubleword-only. OpenAI users must select `"24h"` for batch
   inference or use the upstream OpenAI client for realtime inference.
 - No automatic escalation to realtime if flex or batch inference is delayed.

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -92,6 +92,31 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
@@ -99,6 +124,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1217,7 +1243,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1258,7 +1283,6 @@
       "integrity": "sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.135.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -1478,7 +1502,6 @@
       "integrity": "sha512-0Vb9eKU47njkxv/6B8CRZRDsxNDT/Pz+BIU+M5jw7xL3TdzAjSxlZUxu0xFL/kLpaG3sHZ0LH2wbK1T1yo7CUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -1498,7 +1521,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "openai": ">=4.0.0 <7"
+        "openai": ">=4.104.0 <7"
       },
       "bin": {
         "autobatcher": "dist/cli.js"
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "tsdown": "^0.22.2",
+        "tsx": "^4.20.6",
         "typescript": "^5.7.0"
       },
       "engines": {
@@ -91,38 +92,457 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
-      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -429,6 +849,40 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.1.tgz",
@@ -581,6 +1035,48 @@
         "node": ">=14"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -607,6 +1103,21 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-tsconfig": {
@@ -706,6 +1217,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -746,6 +1258,7 @@
       "integrity": "sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.135.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -959,12 +1472,33 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tsx": {
+      "version": "4.23.10",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.10.tgz",
+      "integrity": "sha512-0Vb9eKU47njkxv/6B8CRZRDsxNDT/Pz+BIU+M5jw7xL3TdzAjSxlZUxu0xFL/kLpaG3sHZ0LH2wbK1T1yo7CUQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autobatcher",
   "version": "0.5.0",
-  "description": "Drop-in OpenAI client that transparently batches requests via the Batch API",
+  "description": "Drop-in OpenAI client for flex and batch inference",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,14 +27,16 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "test": "tsx --test test/*.test.ts",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "openai": ">=4.0.0 <7"
+    "openai": ">=4.104.0 <7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "tsx": "^4.20.6",
     "tsdown": "^0.22.2",
     "typescript": "^5.7.0"
   },

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -32,7 +32,7 @@ const command = positionals[0];
 
 if (values.help || !command) {
   console.log(`
-autobatcher — OpenAI-compatible HTTP proxy with transparent batching
+autobatcher — OpenAI-compatible HTTP proxy for flex and batch inference
 
 Usage:
   autobatcher serve [options]
@@ -81,7 +81,7 @@ const { close } = serve({
   batchSize: parseInt(values["batch-size"]!, 10),
   batchWindowSeconds: parseInt(values["batch-window"]!, 10),
   pollIntervalSeconds: parseInt(values["poll-interval"]!, 10),
-  completionWindow: values.mode === "batch" ? "24h" : "1h",
+  completionWindow: values.mode === "batch" ? "24h" : undefined,
 });
 
 // Graceful shutdown

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1,11 +1,11 @@
 /**
  * BatchOpenAI – an OpenAI subclass that intercepts chat.completions.create(),
- * embeddings.create(), and responses.create() and routes them through the
- * OpenAI-compatible Batch API.
+ * embeddings.create(), and responses.create(). Text uses background flex
+ * polling by default; embeddings and explicit 24-hour calls use the Batch API.
  *
- * Concurrent calls are collected into a queue, serialised as JSONL, uploaded
- * as a batch input file, and polled until results are available. Each original
- * caller's Promise is resolved with the corresponding result.
+ * Flex calls submit immediately and poll by response ID without holding the
+ * submission connection open. Batch calls retain queue, JSONL, upload, poll,
+ * and result-distribution behavior.
  *
  * This mirrors the Python `autobatcher.BatchOpenAI` class.
  */
@@ -20,6 +20,10 @@ import type {
   CreateEmbeddingResponse,
   EmbeddingCreateParams,
 } from "openai/resources/embeddings";
+import type {
+  Response as OpenAIResponse,
+  ResponseCreateParamsNonStreaming,
+} from "openai/resources/responses/responses";
 /** Runtime-agnostic UUID — works in Node, Deno, Bun, and Cloudflare Workers. */
 const uuid = (): string =>
   (globalThis.crypto as unknown as { randomUUID(): string }).randomUUID();
@@ -33,9 +37,9 @@ export interface BatchOpenAIOptions extends OpenAIClientOptions {
   batchSize?: number;
   /** Seconds to wait before flushing a partial batch (default 10). */
   batchWindowSeconds?: number;
-  /** Seconds between poll ticks when waiting for batch completion (default 5). */
+  /** Seconds between flex or batch poll ticks (default 5). */
   pollIntervalSeconds?: number;
-  /** Completion window: "24h" for batch inference (default), "1h" for async inference. */
+  /** Set to "24h" for batch inference; otherwise use flex polling (default). */
   completionWindow?: string;
 }
 
@@ -96,6 +100,17 @@ class BatchedEmbeddings {
   }
 }
 
+class BatchedResponses {
+  constructor(private client: BatchOpenAI) {}
+
+  create(body: ResponseCreateParamsNonStreaming): Promise<OpenAIResponse> {
+    return this.client._enqueue(
+      "/v1/responses",
+      body as unknown as Record<string, unknown>,
+    ) as Promise<OpenAIResponse>;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -103,24 +118,163 @@ class BatchedEmbeddings {
 /** Strip undefined values so JSON.stringify produces clean output. */
 function cleanParams(obj: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
+  const extraBody = obj.extra_body;
   for (const [k, v] of Object.entries(obj)) {
-    if (v !== undefined) {
+    if (
+      v !== undefined &&
+      k !== "extra_body" &&
+      k !== "extra_headers" &&
+      k !== "extra_query" &&
+      k !== "timeout"
+    ) {
       out[k] = v;
     }
   }
+  if (extraBody && typeof extraBody === "object" && !Array.isArray(extraBody)) {
+    Object.assign(out, extraBody);
+  }
   return out;
+}
+
+export function chatParamsToResponse(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const translated = cleanParams(params);
+  const n = translated.n ?? 1;
+  delete translated.n;
+  if (n !== 1) {
+    throw new Error("Flex inference supports only n=1 for chat completions");
+  }
+
+  const messages = translated.messages;
+  delete translated.messages;
+  if (!messages) {
+    throw new Error("Chat completions require messages");
+  }
+  translated.input = messages;
+
+  const maxCompletionTokens = translated.max_completion_tokens;
+  const legacyMaxTokens = translated.max_tokens;
+  delete translated.max_completion_tokens;
+  delete translated.max_tokens;
+  if (maxCompletionTokens !== undefined) {
+    translated.max_output_tokens = maxCompletionTokens;
+  } else if (legacyMaxTokens !== undefined) {
+    translated.max_output_tokens = legacyMaxTokens;
+  }
+
+  const responseFormat = translated.response_format;
+  delete translated.response_format;
+  if (responseFormat !== undefined) {
+    translated.text = { format: responseFormat };
+  }
+
+  delete translated.stream_options;
+  translated.stream = false;
+  return translated;
+}
+
+export function responseToChatCompletion(
+  response: OpenAIResponse,
+): ChatCompletion {
+  const textParts: string[] = [];
+  const toolCalls: Array<{
+    id: string;
+    type: "function";
+    function: { name: string; arguments: string };
+  }> = [];
+
+  for (const rawItem of response.output) {
+    const item = rawItem as unknown as Record<string, unknown>;
+    if (item.type === "message") {
+      const content = item.content;
+      if (typeof content === "string") {
+        textParts.push(content);
+      } else if (Array.isArray(content)) {
+        for (const rawPart of content) {
+          const part = rawPart as Record<string, unknown>;
+          if (part.type === "output_text" && typeof part.text === "string") {
+            textParts.push(part.text);
+          }
+        }
+      }
+
+      const messageToolCalls = item.tool_calls;
+      if (Array.isArray(messageToolCalls)) {
+        for (const rawCall of messageToolCalls) {
+          const call = rawCall as Record<string, unknown>;
+          const fn = (call.function ?? {}) as Record<string, unknown>;
+          toolCalls.push({
+            id: String(call.id ?? call.call_id),
+            type: "function",
+            function: {
+              name: String(fn.name ?? call.name),
+              arguments: String(fn.arguments ?? call.arguments ?? "{}"),
+            },
+          });
+        }
+      }
+    } else if (item.type === "function_call") {
+      toolCalls.push({
+        id: String(item.call_id ?? item.id),
+        type: "function",
+        function: {
+          name: String(item.name),
+          arguments: String(item.arguments ?? "{}"),
+        },
+      });
+    }
+  }
+
+  const message: ChatCompletion["choices"][number]["message"] = {
+    role: "assistant",
+    content: textParts.length > 0 ? textParts.join("") : null,
+    refusal: null,
+  };
+  if (toolCalls.length > 0) message.tool_calls = toolCalls;
+
+  return {
+    id: response.id,
+    object: "chat.completion",
+    created: response.created_at,
+    model: response.model,
+    choices: [
+      {
+        index: 0,
+        message,
+        logprobs: null,
+        finish_reason: toolCalls.length > 0 ? "tool_calls" : "stop",
+      },
+    ],
+    usage: response.usage
+      ? {
+          prompt_tokens: response.usage.input_tokens,
+          completion_tokens: response.usage.output_tokens,
+          total_tokens: response.usage.total_tokens,
+        }
+      : undefined,
+    service_tier: "flex",
+  };
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function getHeader(headers: unknown, name: string): string | null {
+  if (!headers || typeof headers !== "object") return null;
+  const source = headers as Record<string, unknown> & { get?: unknown };
+  if (typeof source.get === "function") {
+    return source.get.call(headers, name) as string | null;
+  }
+  const raw = source[name] ?? source[name.toLowerCase()];
+  if (raw == null) return null;
+  return Array.isArray(raw) ? raw.join(", ") : String(raw);
+}
+
 /** Extract retry delay in seconds from a Retry-After header, defaulting to 60s. */
-function parseRetryAfter(
-  headers: { get(name: string): string | null } | null | undefined,
-  defaultSeconds = 60,
-): number {
-  const raw = headers?.get("retry-after");
+function parseRetryAfter(headers: unknown, defaultSeconds = 60): number {
+  const raw = getHeader(headers, "retry-after");
   if (raw != null) {
     const parsed = Number(raw);
     if (!Number.isNaN(parsed)) return Math.max(parsed, 1);
@@ -136,7 +290,7 @@ export class BatchOpenAI extends OpenAI {
   private readonly _batchSize: number;
   private readonly _batchWindowSeconds: number;
   private readonly _pollIntervalSeconds: number;
-  private readonly _completionWindow: string;
+  private readonly _completionWindow: string | undefined;
 
   private _pending: PendingRequest[] = [];
   private _windowTimer: ReturnType<typeof setTimeout> | null = null;
@@ -147,6 +301,8 @@ export class BatchOpenAI extends OpenAI {
   private readonly _files: OpenAI["files"];
   /** The parent's batches resource, saved before we shadow anything. */
   private readonly _batches: OpenAI["batches"];
+  /** The parent's responses resource used for flex submission and polling. */
+  private readonly _responses: OpenAI["responses"];
 
   constructor(options: BatchOpenAIOptions = {}) {
     const { batchSize, batchWindowSeconds, pollIntervalSeconds, completionWindow, ...openaiOpts } = options;
@@ -155,15 +311,17 @@ export class BatchOpenAI extends OpenAI {
     this._batchSize = batchSize ?? 1000;
     this._batchWindowSeconds = batchWindowSeconds ?? 10;
     this._pollIntervalSeconds = pollIntervalSeconds ?? 5;
-    this._completionWindow = completionWindow ?? "24h";
+    this._completionWindow = completionWindow;
 
     // Save references to the parent's real resources before overwriting.
     this._files = this.files;
     this._batches = this.batches;
+    this._responses = this.responses;
 
-    // Shadow the parent's chat and embeddings with our batching proxies.
+    // Shadow intercepted resources with routing proxies.
     (this as Record<string, unknown>).chat = new BatchedChat(this);
     (this as Record<string, unknown>).embeddings = new BatchedEmbeddings(this);
+    (this as Record<string, unknown>).responses = new BatchedResponses(this);
   }
 
   // -----------------------------------------------------------------------
@@ -181,6 +339,17 @@ export class BatchOpenAI extends OpenAI {
       );
     }
 
+    if (endpoint !== "/v1/embeddings" && this._completionWindow !== "24h") {
+      return this._executeFlex(endpoint, params);
+    }
+
+    return this._enqueueBatch(endpoint, params);
+  }
+
+  private _enqueueBatch(
+    endpoint: string,
+    params: Record<string, unknown>,
+  ): Promise<unknown> {
     return new Promise<unknown>((resolve, reject) => {
       this._pending.push({
         customId: uuid(),
@@ -199,6 +368,43 @@ export class BatchOpenAI extends OpenAI {
         }, this._batchWindowSeconds * 1000);
       }
     });
+  }
+
+  private async _executeFlex(
+    endpoint: string,
+    params: Record<string, unknown>,
+  ): Promise<OpenAIResponse | ChatCompletion> {
+    const submitParams =
+      endpoint === "/v1/chat/completions"
+        ? chatParamsToResponse(params)
+        : cleanParams(params);
+    if (endpoint !== "/v1/chat/completions" && endpoint !== "/v1/responses") {
+      throw new Error(`Flex inference is not supported for ${endpoint}`);
+    }
+
+    delete submitParams.stream_options;
+    submitParams.stream = false;
+    submitParams.service_tier = "flex";
+    submitParams.background = true;
+
+    let response = await this._responses.create(
+      submitParams as unknown as ResponseCreateParamsNonStreaming,
+    );
+    while (response.status === "queued" || response.status === "in_progress") {
+      await sleep(this._pollIntervalSeconds * 1000);
+      response = await this._responses.retrieve(response.id);
+    }
+
+    if (response.status !== "completed") {
+      const detail = response.error?.message ?? "no error details";
+      throw new Error(
+        `Flex response ${response.id} reached terminal status ${response.status}: ${detail}`,
+      );
+    }
+
+    return endpoint === "/v1/chat/completions"
+      ? responseToChatCompletion(response)
+      : response;
   }
 
   private _scheduleFlush(): void {
@@ -254,7 +460,7 @@ export class BatchOpenAI extends OpenAI {
           if (err instanceof OpenAI.RateLimitError) {
             const retryAfter = parseRetryAfter(err.headers);
             console.info(
-              `[autobatcher] Rate limited uploading batch file, retrying in ${retryAfter}s (Retry-After: ${err.headers?.get("retry-after") ?? "not set"})`,
+              `[autobatcher] Rate limited uploading batch file, retrying in ${retryAfter}s (Retry-After: ${getHeader(err.headers, "retry-after") ?? "not set"})`,
             );
             await sleep(retryAfter * 1000);
             continue;
@@ -270,14 +476,14 @@ export class BatchOpenAI extends OpenAI {
           batchJob = await this._batches.create({
             input_file_id: file.id,
             endpoint: batchEndpoint as "/v1/chat/completions",
-            completion_window: this._completionWindow as "24h",
+            completion_window: "24h",
           });
           break;
         } catch (err) {
           if (err instanceof OpenAI.RateLimitError) {
             const retryAfter = parseRetryAfter(err.headers);
             console.info(
-              `[autobatcher] Rate limited creating batch, retrying in ${retryAfter}s (Retry-After: ${err.headers?.get("retry-after") ?? "not set"})`,
+              `[autobatcher] Rate limited creating batch, retrying in ${retryAfter}s (Retry-After: ${getHeader(err.headers, "retry-after") ?? "not set"})`,
             );
             await sleep(retryAfter * 1000);
             continue;
@@ -427,9 +633,9 @@ export class BatchOpenAI extends OpenAI {
   }
 }
 
-/** BatchOpenAI variant defaulting to 1h completion window (async inference). */
+/** Compatibility alias for the default flex-inference client. */
 export class AsyncOpenAI extends BatchOpenAI {
   constructor(options: BatchOpenAIOptions = {}) {
-    super({ completionWindow: "1h", ...options });
+    super(options);
   }
 }

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -30,6 +30,10 @@ import {
   responseToChatCompletion,
 } from "./translation.js";
 
+type OpenAIRequestOptions = NonNullable<
+  Parameters<OpenAI["responses"]["create"]>[1]
+>;
+
 export { chatParamsToResponse, responseToChatCompletion } from "./translation.js";
 /** Runtime-agnostic UUID — works in Node, Deno, Bun, and Cloudflare Workers. */
 const uuid = (): string =>
@@ -71,59 +75,55 @@ interface BatchLineResult {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Proxy resource classes
-// ---------------------------------------------------------------------------
-
-class BatchedCompletions {
-  constructor(private client: BatchOpenAI) {}
-
-  create(
-    body: ChatCompletionCreateParamsNonStreaming,
-  ): Promise<ChatCompletion> {
-    return this.client._enqueue(
-      "/v1/chat/completions",
-      body as unknown as Record<string, unknown>,
-    ) as Promise<ChatCompletion>;
-  }
-}
-
-class BatchedChat {
-  completions: BatchedCompletions;
-
-  constructor(client: BatchOpenAI) {
-    this.completions = new BatchedCompletions(client);
-  }
-}
-
-class BatchedEmbeddings {
-  constructor(private client: BatchOpenAI) {}
-
-  create(body: EmbeddingCreateParams): Promise<CreateEmbeddingResponse> {
-    return this.client._enqueue(
-      "/v1/embeddings",
-      body as unknown as Record<string, unknown>,
-    ) as Promise<CreateEmbeddingResponse>;
-  }
-}
-
-class BatchedResponses {
-  constructor(private client: BatchOpenAI) {}
-
-  create(body: ResponseCreateParamsNonStreaming): Promise<OpenAIResponse> {
-    return this.client._enqueue(
-      "/v1/responses",
-      body as unknown as Record<string, unknown>,
-    ) as Promise<OpenAIResponse>;
-  }
+interface ActiveFlexOperation {
+  controller: AbortController;
+  responseId?: string;
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function abortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) return signal.reason;
+  const error = new Error("The operation was aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function sleep(ms: number, signal?: AbortSignal | null): Promise<void> {
+  if (signal?.aborted) return Promise.reject(abortError(signal));
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortError(signal!));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function overrideCreate<T extends object, Args extends unknown[], Result>(
+  resource: T,
+  create: (...args: Args) => Result,
+): T {
+  return new Proxy(resource, {
+    get(target, property) {
+      if (property === "create") return create;
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+function hasRequestOptions(options: OpenAIRequestOptions | undefined): boolean {
+  return (
+    options != null &&
+    Object.values(options).some((value) => value !== undefined)
+  );
 }
 
 function getHeader(headers: unknown, name: string): string | null {
@@ -157,9 +157,13 @@ export class BatchOpenAI extends OpenAI {
   private readonly _pollIntervalSeconds: number;
   private readonly _completionWindow: string | undefined;
 
-  private _pending: PendingRequest[] = [];
-  private _windowTimer: ReturnType<typeof setTimeout> | null = null;
-  private _inflightBatches: Promise<void>[] = [];
+  private _pending = new Map<string, PendingRequest[]>();
+  private _windowTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  private _inflightBatches = new Set<Promise<void>>();
+  private _activeFlex = new Map<Promise<unknown>, ActiveFlexOperation>();
   private _closed = false;
 
   /** The parent's files resource, saved before we shadow anything. */
@@ -168,6 +172,9 @@ export class BatchOpenAI extends OpenAI {
   private readonly _batches: OpenAI["batches"];
   /** The parent's responses resource used for flex submission and polling. */
   private readonly _responses: OpenAI["responses"];
+  /** Parent resources retained for all non-create operations. */
+  private readonly _chat: OpenAI["chat"];
+  private readonly _embeddings: OpenAI["embeddings"];
 
   constructor(options: BatchOpenAIOptions = {}) {
     const { batchSize, batchWindowSeconds, pollIntervalSeconds, completionWindow, ...openaiOpts } = options;
@@ -179,14 +186,53 @@ export class BatchOpenAI extends OpenAI {
     this._completionWindow = completionWindow;
 
     // Save references to the parent's real resources before overwriting.
+    this._chat = this.chat;
+    this._embeddings = this.embeddings;
     this._files = this.files;
     this._batches = this.batches;
     this._responses = this.responses;
 
     // Shadow intercepted resources with routing proxies.
-    (this as Record<string, unknown>).chat = new BatchedChat(this);
-    (this as Record<string, unknown>).embeddings = new BatchedEmbeddings(this);
-    (this as Record<string, unknown>).responses = new BatchedResponses(this);
+    const completions = overrideCreate(
+      this._chat.completions,
+      (
+        body: ChatCompletionCreateParamsNonStreaming,
+        requestOptions?: OpenAIRequestOptions,
+      ) =>
+        this._enqueue(
+          "/v1/chat/completions",
+          body as unknown as Record<string, unknown>,
+          requestOptions,
+        ) as Promise<ChatCompletion>,
+    );
+    (this as Record<string, unknown>).chat = new Proxy(this._chat, {
+      get(target, property) {
+        if (property === "completions") return completions;
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    (this as Record<string, unknown>).embeddings = overrideCreate(
+      this._embeddings,
+      (body: EmbeddingCreateParams, requestOptions?: OpenAIRequestOptions) =>
+        this._enqueue(
+          "/v1/embeddings",
+          body as unknown as Record<string, unknown>,
+          requestOptions,
+        ) as Promise<CreateEmbeddingResponse>,
+    );
+    (this as Record<string, unknown>).responses = overrideCreate(
+      this._responses,
+      (
+        body: ResponseCreateParamsNonStreaming,
+        options?: OpenAIRequestOptions,
+      ) =>
+        this._enqueue(
+          "/v1/responses",
+          body as unknown as Record<string, unknown>,
+          options,
+        ) as Promise<OpenAIResponse>,
+    );
   }
 
   // -----------------------------------------------------------------------
@@ -197,6 +243,7 @@ export class BatchOpenAI extends OpenAI {
   _enqueue(
     endpoint: string,
     params: Record<string, unknown>,
+    options?: OpenAIRequestOptions,
   ): Promise<unknown> {
     if (this._closed) {
       return Promise.reject(
@@ -205,10 +252,51 @@ export class BatchOpenAI extends OpenAI {
     }
 
     if (endpoint !== "/v1/embeddings" && this._completionWindow !== "24h") {
-      return this._executeFlex(endpoint, params);
+      return this._startFlex(endpoint, params, options);
+    }
+
+    if (hasRequestOptions(options)) {
+      return Promise.reject(
+        new Error(
+          "Per-request transport options cannot be represented by the Batch API",
+        ),
+      );
     }
 
     return this._enqueueBatch(endpoint, params);
+  }
+
+  private _startFlex(
+    endpoint: string,
+    params: Record<string, unknown>,
+    options?: OpenAIRequestOptions,
+  ): Promise<OpenAIResponse | ChatCompletion> {
+    const operation: ActiveFlexOperation = {
+      controller: new AbortController(),
+    };
+    const callerSignal = options?.signal;
+    const abortFromCaller = () =>
+      operation.controller.abort(callerSignal?.reason);
+    if (callerSignal?.aborted) abortFromCaller();
+    else callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+
+    const requestOptions = {
+      ...options,
+      signal: operation.controller.signal,
+    } as OpenAIRequestOptions;
+    const promise = this._executeFlex(
+      endpoint,
+      params,
+      requestOptions,
+      operation,
+    );
+    this._activeFlex.set(promise, operation);
+    const cleanup = () => {
+      callerSignal?.removeEventListener("abort", abortFromCaller);
+      this._activeFlex.delete(promise);
+    };
+    promise.then(cleanup, cleanup);
+    return promise;
   }
 
   private _enqueueBatch(
@@ -216,21 +304,24 @@ export class BatchOpenAI extends OpenAI {
     params: Record<string, unknown>,
   ): Promise<unknown> {
     return new Promise<unknown>((resolve, reject) => {
-      this._pending.push({
+      const pending = this._pending.get(endpoint) ?? [];
+      pending.push({
         customId: uuid(),
         endpoint,
         body: cleanParams(params),
         resolve,
         reject,
       });
+      this._pending.set(endpoint, pending);
 
-      if (this._pending.length >= this._batchSize) {
-        this._scheduleFlush();
-      } else if (!this._windowTimer) {
-        this._windowTimer = setTimeout(() => {
-          this._windowTimer = null;
-          this._scheduleFlush();
+      if (pending.length >= this._batchSize) {
+        this._scheduleFlush(endpoint);
+      } else if (!this._windowTimers.has(endpoint)) {
+        const timer = setTimeout(() => {
+          this._windowTimers.delete(endpoint);
+          this._scheduleFlush(endpoint);
         }, this._batchWindowSeconds * 1000);
+        this._windowTimers.set(endpoint, timer);
       }
     });
   }
@@ -238,6 +329,8 @@ export class BatchOpenAI extends OpenAI {
   private async _executeFlex(
     endpoint: string,
     params: Record<string, unknown>,
+    options?: OpenAIRequestOptions,
+    operation?: ActiveFlexOperation,
   ): Promise<OpenAIResponse | ChatCompletion> {
     const submitParams =
       endpoint === "/v1/chat/completions"
@@ -252,52 +345,63 @@ export class BatchOpenAI extends OpenAI {
     submitParams.service_tier = "flex";
     submitParams.background = true;
 
-    let response = await this._responses.create(
-      submitParams as unknown as ResponseCreateParamsNonStreaming,
-    );
-    while (response.status === "queued" || response.status === "in_progress") {
-      await sleep(this._pollIntervalSeconds * 1000);
-      response = await this._responses.retrieve(response.id);
-    }
-
-    if (response.status !== "completed") {
-      const detail = response.error?.message ?? "no error details";
-      throw new Error(
-        `Flex response ${response.id} reached terminal status ${response.status}: ${detail}`,
+    try {
+      let response = await this._responses.create(
+        submitParams as unknown as ResponseCreateParamsNonStreaming,
+        options,
       );
-    }
+      if (operation) operation.responseId = response.id;
+      while (response.status === "queued" || response.status === "in_progress") {
+        await sleep(this._pollIntervalSeconds * 1000, options?.signal);
+        response = await this._responses.retrieve(response.id, undefined, options);
+      }
 
-    return endpoint === "/v1/chat/completions"
-      ? responseToChatCompletion(response)
-      : response;
+      if (response.status !== "completed") {
+        const detail = response.error?.message ?? "no error details";
+        throw new Error(
+          `Flex response ${response.id} reached terminal status ${response.status}: ${detail}`,
+        );
+      }
+
+      return endpoint === "/v1/chat/completions"
+        ? responseToChatCompletion(response)
+        : response;
+    } catch (error) {
+      if (options?.signal?.aborted && operation?.responseId) {
+        try {
+          await this._responses.cancel(operation.responseId);
+        } catch {
+          // Preserve the caller's cancellation error if upstream cleanup fails.
+        }
+      }
+      throw error;
+    }
   }
 
-  private _scheduleFlush(): void {
-    if (this._pending.length === 0) return;
-    const p = this._flush();
-    this._inflightBatches.push(p);
-    p.finally(() => {
-      const idx = this._inflightBatches.indexOf(p);
-      if (idx >= 0) this._inflightBatches.splice(idx, 1);
-    });
+  private _scheduleFlush(endpoint: string): void {
+    if ((this._pending.get(endpoint)?.length ?? 0) === 0) return;
+    const promise = this._flush(endpoint);
+    this._inflightBatches.add(promise);
+    const remove = () => this._inflightBatches.delete(promise);
+    promise.then(remove, remove);
   }
 
   // -----------------------------------------------------------------------
   // Flush: submit batch, poll, distribute results
   // -----------------------------------------------------------------------
 
-  private async _flush(): Promise<void> {
-    if (this._pending.length === 0) return;
+  private async _flush(endpoint: string): Promise<void> {
+    const pending = this._pending.get(endpoint);
+    if (!pending?.length) return;
 
-    const batch = this._pending.splice(0, this._pending.length);
+    const batch = pending.splice(0, pending.length);
+    this._pending.delete(endpoint);
 
-    if (this._windowTimer) {
-      clearTimeout(this._windowTimer);
-      this._windowTimer = null;
-    }
+    const timer = this._windowTimers.get(endpoint);
+    if (timer) clearTimeout(timer);
+    this._windowTimers.delete(endpoint);
 
-    // Determine the endpoint for this batch (use the first request's endpoint).
-    const batchEndpoint = batch[0].endpoint;
+    const batchEndpoint = endpoint;
 
     try {
       // 1. Build JSONL
@@ -307,13 +411,18 @@ export class BatchOpenAI extends OpenAI {
             custom_id: r.customId,
             method: "POST",
             url: r.endpoint,
-            body: r.body,
+            body: (() => {
+              const body = { ...r.body };
+              delete body.stream_options;
+              if (r.endpoint !== "/v1/embeddings") body.stream = false;
+              return body;
+            })(),
           }),
         )
         .join("\n");
 
       // 2. Upload file via the parent's (real) files resource (retry on rate limit).
-      let file: Awaited<ReturnType<typeof this._files.create>>;
+      let file: Awaited<ReturnType<OpenAI["files"]["create"]>>;
       while (true) {
         try {
           file = await this._files.create({
@@ -335,7 +444,7 @@ export class BatchOpenAI extends OpenAI {
       }
 
       // 3. Create batch via the parent's (real) batches resource (retry on rate limit).
-      let batchJob: Awaited<ReturnType<typeof this._batches.create>>;
+      let batchJob: Awaited<ReturnType<OpenAI["batches"]["create"]>>;
       while (true) {
         try {
           batchJob = await this._batches.create({
@@ -485,16 +594,20 @@ export class BatchOpenAI extends OpenAI {
   async close(): Promise<void> {
     this._closed = true;
 
-    if (this._windowTimer) {
-      clearTimeout(this._windowTimer);
-      this._windowTimer = null;
+    const activeFlex = Array.from(this._activeFlex.entries());
+    for (const [, operation] of activeFlex) {
+      operation.controller.abort(new Error("BatchOpenAI closed"));
+    }
+    await Promise.allSettled(activeFlex.map(([promise]) => promise));
+
+    for (const timer of this._windowTimers.values()) clearTimeout(timer);
+    this._windowTimers.clear();
+
+    for (const endpoint of Array.from(this._pending.keys())) {
+      this._scheduleFlush(endpoint);
     }
 
-    if (this._pending.length > 0) {
-      this._scheduleFlush();
-    }
-
-    await Promise.all(this._inflightBatches);
+    await Promise.all(Array.from(this._inflightBatches));
   }
 }
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -24,6 +24,13 @@ import type {
   Response as OpenAIResponse,
   ResponseCreateParamsNonStreaming,
 } from "openai/resources/responses/responses";
+import {
+  chatParamsToResponse,
+  cleanParams,
+  responseToChatCompletion,
+} from "./translation.js";
+
+export { chatParamsToResponse, responseToChatCompletion } from "./translation.js";
 /** Runtime-agnostic UUID — works in Node, Deno, Bun, and Cloudflare Workers. */
 const uuid = (): string =>
   (globalThis.crypto as unknown as { randomUUID(): string }).randomUUID();
@@ -114,148 +121,6 @@ class BatchedResponses {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Strip undefined values so JSON.stringify produces clean output. */
-function cleanParams(obj: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  const extraBody = obj.extra_body;
-  for (const [k, v] of Object.entries(obj)) {
-    if (
-      v !== undefined &&
-      k !== "extra_body" &&
-      k !== "extra_headers" &&
-      k !== "extra_query" &&
-      k !== "timeout"
-    ) {
-      out[k] = v;
-    }
-  }
-  if (extraBody && typeof extraBody === "object" && !Array.isArray(extraBody)) {
-    Object.assign(out, extraBody);
-  }
-  return out;
-}
-
-export function chatParamsToResponse(
-  params: Record<string, unknown>,
-): Record<string, unknown> {
-  const translated = cleanParams(params);
-  const n = translated.n ?? 1;
-  delete translated.n;
-  if (n !== 1) {
-    throw new Error("Flex inference supports only n=1 for chat completions");
-  }
-
-  const messages = translated.messages;
-  delete translated.messages;
-  if (!messages) {
-    throw new Error("Chat completions require messages");
-  }
-  translated.input = messages;
-
-  const maxCompletionTokens = translated.max_completion_tokens;
-  const legacyMaxTokens = translated.max_tokens;
-  delete translated.max_completion_tokens;
-  delete translated.max_tokens;
-  if (maxCompletionTokens !== undefined) {
-    translated.max_output_tokens = maxCompletionTokens;
-  } else if (legacyMaxTokens !== undefined) {
-    translated.max_output_tokens = legacyMaxTokens;
-  }
-
-  const responseFormat = translated.response_format;
-  delete translated.response_format;
-  if (responseFormat !== undefined) {
-    translated.text = { format: responseFormat };
-  }
-
-  delete translated.stream_options;
-  translated.stream = false;
-  return translated;
-}
-
-export function responseToChatCompletion(
-  response: OpenAIResponse,
-): ChatCompletion {
-  const textParts: string[] = [];
-  const toolCalls: Array<{
-    id: string;
-    type: "function";
-    function: { name: string; arguments: string };
-  }> = [];
-
-  for (const rawItem of response.output) {
-    const item = rawItem as unknown as Record<string, unknown>;
-    if (item.type === "message") {
-      const content = item.content;
-      if (typeof content === "string") {
-        textParts.push(content);
-      } else if (Array.isArray(content)) {
-        for (const rawPart of content) {
-          const part = rawPart as Record<string, unknown>;
-          if (part.type === "output_text" && typeof part.text === "string") {
-            textParts.push(part.text);
-          }
-        }
-      }
-
-      const messageToolCalls = item.tool_calls;
-      if (Array.isArray(messageToolCalls)) {
-        for (const rawCall of messageToolCalls) {
-          const call = rawCall as Record<string, unknown>;
-          const fn = (call.function ?? {}) as Record<string, unknown>;
-          toolCalls.push({
-            id: String(call.id ?? call.call_id),
-            type: "function",
-            function: {
-              name: String(fn.name ?? call.name),
-              arguments: String(fn.arguments ?? call.arguments ?? "{}"),
-            },
-          });
-        }
-      }
-    } else if (item.type === "function_call") {
-      toolCalls.push({
-        id: String(item.call_id ?? item.id),
-        type: "function",
-        function: {
-          name: String(item.name),
-          arguments: String(item.arguments ?? "{}"),
-        },
-      });
-    }
-  }
-
-  const message: ChatCompletion["choices"][number]["message"] = {
-    role: "assistant",
-    content: textParts.length > 0 ? textParts.join("") : null,
-    refusal: null,
-  };
-  if (toolCalls.length > 0) message.tool_calls = toolCalls;
-
-  return {
-    id: response.id,
-    object: "chat.completion",
-    created: response.created_at,
-    model: response.model,
-    choices: [
-      {
-        index: 0,
-        message,
-        logprobs: null,
-        finish_reason: toolCalls.length > 0 ? "tool_calls" : "stop",
-      },
-    ],
-    usage: response.usage
-      ? {
-          prompt_tokens: response.usage.input_tokens,
-          completion_tokens: response.usage.output_tokens,
-          total_tokens: response.usage.total_tokens,
-        }
-      : undefined,
-    service_tier: "flex",
-  };
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,9 +1,9 @@
 /**
- * autobatcher – Drop-in OpenAI client that transparently batches requests.
+ * autobatcher – Drop-in OpenAI client for flex and batch inference.
  *
  * Usage:
- *   import { BatchOpenAI } from "autobatcher";   // 24h batch inference (default)
- *   import { AsyncOpenAI } from "autobatcher";   // 1h async inference
+ *   import { BatchOpenAI } from "autobatcher";   // flex polling by default
+ *   import { AsyncOpenAI } from "autobatcher";   // equivalent compatibility name
  *
  *   const client = new BatchOpenAI({ apiKey: "..." });
  *   const response = await client.chat.completions.create({

--- a/typescript/src/serve.ts
+++ b/typescript/src/serve.ts
@@ -38,6 +38,9 @@ const BATCHED_ROUTES = new Set([
   "/v1/embeddings",
   "/v1/responses",
 ]);
+const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
+
+class PayloadTooLargeError extends Error {}
 
 function jsonResponse(res: ServerResponse, status: number, body: unknown): void {
   const json = JSON.stringify(body);
@@ -49,9 +52,26 @@ function jsonResponse(res: ServerResponse, status: number, body: unknown): void 
 }
 
 async function readBody(req: IncomingMessage): Promise<string> {
+  const declaredLength = Number(req.headers["content-length"] ?? 0);
+  let tooLarge =
+    Number.isFinite(declaredLength) &&
+    declaredLength > MAX_REQUEST_BODY_BYTES;
+
   const chunks: Buffer[] = [];
+  let totalBytes = 0;
   for await (const chunk of req) {
-    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    const buffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_REQUEST_BODY_BYTES) {
+      tooLarge = true;
+      chunks.length = 0;
+    }
+    if (!tooLarge) {
+      chunks.push(buffer);
+    }
+  }
+  if (tooLarge) {
+    throw new PayloadTooLargeError("Request body exceeds the 1 MiB limit");
   }
   return Buffer.concat(chunks).toString("utf-8");
 }
@@ -136,8 +156,12 @@ export function serve(options: ServeOptions): {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log("request_error", { url, error: message });
-      jsonResponse(res, 500, {
-        error: { message, type: "server_error" },
+      const status = err instanceof PayloadTooLargeError ? 413 : 500;
+      jsonResponse(res, status, {
+        error: {
+          message,
+          type: status === 413 ? "invalid_request_error" : "server_error",
+        },
       });
     }
   });

--- a/typescript/src/serve.ts
+++ b/typescript/src/serve.ts
@@ -1,6 +1,6 @@
 /**
- * autobatcher serve — local OpenAI-compatible HTTP proxy that transparently
- * batches incoming requests via BatchOpenAI.
+ * autobatcher serve — local OpenAI-compatible HTTP proxy for flex and batch
+ * inference via BatchOpenAI.
  *
  * Usage:
  *   npx autobatcher serve --base-url https://api.doubleword.ai/v1 --api-key sk-...
@@ -71,7 +71,7 @@ function log(event: string, data: Record<string, unknown> = {}): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Start an OpenAI-compatible HTTP proxy that batches requests.
+ * Start an OpenAI-compatible HTTP proxy using flex polling by default.
  * Returns the server instance and a close function.
  */
 export function serve(options: ServeOptions): {
@@ -100,7 +100,7 @@ export function serve(options: ServeOptions): {
       return;
     }
 
-    // Only accept POST to batched routes
+    // Only accept POST to intercepted inference routes
     if (method !== "POST" || !BATCHED_ROUTES.has(url)) {
       jsonResponse(res, 404, {
         error: { message: `Route not found: ${method} ${url}`, type: "invalid_request_error" },
@@ -125,8 +125,7 @@ export function serve(options: ServeOptions): {
           result = await client.embeddings.create(params as unknown as Parameters<typeof client.embeddings.create>[0]);
           break;
         case "/v1/responses":
-          // Responses API — enqueue directly
-          result = await client._enqueue("/v1/responses", params);
+          result = await client.responses.create(params as unknown as Parameters<typeof client.responses.create>[0]);
           break;
         default:
           jsonResponse(res, 404, { error: { message: "Not found" } });

--- a/typescript/src/translation.ts
+++ b/typescript/src/translation.ts
@@ -1,0 +1,488 @@
+/** Typed Chat Completions ↔ Responses adapters using public OpenAI SDK types. */
+
+import type {
+  ChatCompletion,
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionMessageParam,
+} from "openai/resources/chat/completions";
+import type {
+  EasyInputMessage,
+  Response as OpenAIResponse,
+  ResponseCreateParamsNonStreaming,
+  ResponseInputItem,
+  ResponseInputMessageContentList,
+} from "openai/resources/responses/responses";
+
+type ResponseRequest = ResponseCreateParamsNonStreaming &
+  Record<string, unknown>;
+type ChatFunctionToolCall = Extract<
+  NonNullable<
+    ChatCompletion["choices"][number]["message"]["tool_calls"]
+  >[number],
+  { type: "function" }
+>;
+
+/** Strip transport options and merge extra_body into the API payload. */
+export function cleanParams(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const extraBody = obj.extra_body;
+  for (const [key, value] of Object.entries(obj)) {
+    if (
+      value !== undefined &&
+      key !== "extra_body" &&
+      key !== "extra_headers" &&
+      key !== "extra_query" &&
+      key !== "timeout"
+    ) {
+      out[key] = value;
+    }
+  }
+  if (
+    extraBody &&
+    typeof extraBody === "object" &&
+    !Array.isArray(extraBody)
+  ) {
+    Object.assign(out, extraBody);
+  }
+  return out;
+}
+
+function record(value: unknown, parameter: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${parameter} is invalid`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function textContent(content: unknown, parameter: string): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) {
+    throw new Error(`${parameter} content must be text`);
+  }
+  return content
+    .map((rawPart) => {
+      const part = record(rawPart, `${parameter} content part`);
+      if (part.type !== "text" || typeof part.text !== "string") {
+        throw new Error(`${parameter} supports text content only`);
+      }
+      return part.text;
+    })
+    .join("");
+}
+
+function inputContent(
+  content: unknown,
+  parameter: string,
+): EasyInputMessage["content"] {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) {
+    throw new Error(`${parameter} content must be text or content parts`);
+  }
+
+  const converted: ResponseInputMessageContentList = [];
+  for (const rawPart of content) {
+    const part = record(rawPart, `${parameter} content part`);
+    switch (part.type) {
+      case "text": {
+        if (typeof part.text !== "string") {
+          throw new Error(`${parameter} text content must be a string`);
+        }
+        converted.push({ type: "input_text", text: part.text });
+        break;
+      }
+      case "image_url": {
+        const image = record(part.image_url, `${parameter} image_url`);
+        if (typeof image.url !== "string") {
+          throw new Error(`${parameter} image_url requires a URL`);
+        }
+        const detail = image.detail ?? "auto";
+        if (detail !== "low" && detail !== "high" && detail !== "auto") {
+          throw new Error(`${parameter} image_url detail is invalid`);
+        }
+        converted.push({
+          type: "input_image",
+          image_url: image.url,
+          detail,
+        });
+        break;
+      }
+      case "file": {
+        const file = record(part.file, `${parameter} file content`);
+        if (
+          file.file_data == null &&
+          file.file_id == null
+        ) {
+          throw new Error(
+            `${parameter} file content requires file data or an ID`,
+          );
+        }
+        converted.push({
+          type: "input_file",
+          ...(file.file_data != null ? { file_data: String(file.file_data) } : {}),
+          ...(file.file_id != null ? { file_id: String(file.file_id) } : {}),
+          ...(file.filename != null ? { filename: String(file.filename) } : {}),
+        });
+        break;
+      }
+      case "input_audio":
+        throw new Error(
+          "input_audio is not supported by flex Responses translation",
+        );
+      default:
+        throw new Error(
+          `${parameter} contains unsupported content type ${String(part.type)}`,
+        );
+    }
+  }
+  return converted;
+}
+
+function assistantItems(
+  message: Extract<ChatCompletionMessageParam, { role: "assistant" }>,
+): ResponseInputItem[] {
+  if (message.audio != null) {
+    throw new Error(
+      "assistant audio is not supported by flex Responses translation",
+    );
+  }
+  if (message.function_call != null) {
+    throw new Error(
+      "deprecated function_call is not supported; use tool_calls",
+    );
+  }
+  if (message.name != null) {
+    throw new Error(
+      "assistant name is not supported by flex Responses translation",
+    );
+  }
+
+  const items: ResponseInputItem[] = [];
+  if (message.content != null) {
+    let content: string;
+    if (typeof message.content === "string") {
+      content = message.content;
+    } else {
+      content = Array.from(message.content)
+        .map((part) => {
+          if (part.type === "text") return part.text;
+          if (part.type === "refusal") return part.refusal;
+          throw new Error(
+            "assistant content supports text and refusal parts only",
+          );
+        })
+        .join("");
+    }
+    items.push({ role: "assistant", content } satisfies ResponseInputItem);
+  }
+
+  for (const call of message.tool_calls ?? []) {
+    if (call.type !== "function") {
+      throw new Error(
+        `tool_calls contains unsupported type ${String(call.type)}`,
+      );
+    }
+    if (!call.id) {
+      throw new Error("tool_calls function call requires a non-empty id");
+    }
+    if (!call.function.name) {
+      throw new Error("tool_calls function call requires a non-empty name");
+    }
+    items.push({
+      type: "function_call",
+      call_id: call.id,
+      name: call.function.name,
+      arguments: call.function.arguments,
+    } satisfies ResponseInputItem);
+  }
+  return items;
+}
+
+function messageToResponseItems(
+  message: ChatCompletionMessageParam,
+): ResponseInputItem[] {
+  switch (message.role) {
+    case "assistant":
+      return assistantItems(message);
+    case "tool": {
+      if (!message.tool_call_id) {
+        throw new Error("tool message requires a non-empty tool_call_id");
+      }
+      return [
+        {
+          type: "function_call_output",
+          call_id: message.tool_call_id,
+          output: textContent(message.content, "tool message"),
+        } satisfies ResponseInputItem,
+      ];
+    }
+    case "function":
+      throw new Error(
+        "deprecated function messages are not supported; use tool messages",
+      );
+    case "user":
+    case "system":
+    case "developer": {
+      if (message.name != null) {
+        throw new Error(
+          `${message.role} message name is not supported by flex Responses translation`,
+        );
+      }
+      return [
+        {
+          role: message.role,
+          content: inputContent(message.content, `${message.role} message`),
+        } satisfies ResponseInputItem,
+      ];
+    }
+  }
+}
+
+function messagesToResponseInput(
+  messages: Iterable<ChatCompletionMessageParam>,
+): ResponseInputItem[] {
+  const items: ResponseInputItem[] = [];
+  for (const message of messages) {
+    items.push(...messageToResponseItems(message));
+  }
+  return items;
+}
+
+function convertTools(
+  tools: NonNullable<ChatCompletionCreateParamsNonStreaming["tools"]>,
+): NonNullable<ResponseCreateParamsNonStreaming["tools"]> {
+  return Array.from(tools).map((tool) => {
+    if (tool.type === "function") {
+      return {
+        type: "function",
+        name: tool.function.name,
+        parameters: tool.function.parameters ?? null,
+        strict: tool.function.strict ?? false,
+        ...(tool.function.description != null
+          ? { description: tool.function.description }
+          : {}),
+      } satisfies NonNullable<ResponseCreateParamsNonStreaming["tools"]>[number];
+    }
+    if (tool.type === "custom") {
+      throw new Error(
+        "custom tools are not supported by the minimum OpenAI SDK schema",
+      );
+    }
+    throw new Error(`tools contains unsupported type ${String((tool as { type?: unknown }).type)}`);
+  });
+}
+
+function convertToolChoice(
+  choice: NonNullable<ChatCompletionCreateParamsNonStreaming["tool_choice"]>,
+): NonNullable<ResponseCreateParamsNonStreaming["tool_choice"]> {
+  if (typeof choice === "string") return choice;
+  if (choice.type === "function") {
+    return { type: "function", name: choice.function.name };
+  }
+  if (choice.type === "custom") {
+    throw new Error(
+      "custom tool_choice is not supported by the minimum OpenAI SDK schema",
+    );
+  }
+  throw new Error(`tool_choice contains unsupported type ${choice.type}`);
+}
+
+function convertResponseFormat(
+  responseFormat: NonNullable<
+    ChatCompletionCreateParamsNonStreaming["response_format"]
+  >,
+): NonNullable<
+  NonNullable<ResponseCreateParamsNonStreaming["text"]>["format"]
+> {
+  if (responseFormat.type === "json_schema") {
+    const { name, description, schema, strict } = responseFormat.json_schema;
+    if (schema == null) {
+      throw new Error("response_format json_schema requires schema details");
+    }
+    return {
+      type: "json_schema",
+      name,
+      schema,
+      ...(description != null ? { description } : {}),
+      ...(strict != null ? { strict } : {}),
+    };
+  }
+  return responseFormat;
+}
+
+function rejectUnsupported(
+  params: ChatCompletionCreateParamsNonStreaming & Record<string, unknown>,
+): void {
+  const unsupported: Array<[keyof typeof params, string]> = [
+    ["audio", "audio output"],
+    ["function_call", "deprecated function_call"],
+    ["functions", "deprecated functions"],
+    ["prediction", "prediction"],
+    ["web_search_options", "web_search_options"],
+  ];
+  for (const [key, label] of unsupported) {
+    if (params[key] != null) {
+      throw new Error(
+        `${label} is not supported by flex Responses translation`,
+      );
+    }
+  }
+  if (
+    params.modalities != null &&
+    (params.modalities.length !== 1 || params.modalities[0] !== "text")
+  ) {
+    throw new Error(
+      "modalities supports text output only in flex Responses translation",
+    );
+  }
+}
+
+export function chatParamsToResponse(
+  params: ChatCompletionCreateParamsNonStreaming | Record<string, unknown>,
+): ResponseRequest {
+  const source = cleanParams(params as Record<string, unknown>) as unknown as
+    ChatCompletionCreateParamsNonStreaming & Record<string, unknown>;
+  rejectUnsupported(source);
+
+  if ((source.n ?? 1) !== 1) {
+    throw new Error("Flex inference supports only n=1 for chat completions");
+  }
+  if (source.messages == null) {
+    throw new Error("Chat completions require messages");
+  }
+
+  const result: Record<string, unknown> = {
+    model: source.model,
+    input: messagesToResponseInput(source.messages),
+    stream: false,
+  };
+
+  const sharedFields = [
+    "metadata",
+    "moderation",
+    "parallel_tool_calls",
+    "prompt_cache_key",
+    "prompt_cache_options",
+    "prompt_cache_retention",
+    "safety_identifier",
+    "store",
+    "temperature",
+    "top_logprobs",
+    "top_p",
+    "user",
+  ] as const;
+  for (const key of sharedFields) {
+    if (source[key] != null) result[key] = source[key];
+  }
+
+  const maxOutputTokens =
+    source.max_completion_tokens ?? source.max_tokens;
+  if (maxOutputTokens != null) result.max_output_tokens = maxOutputTokens;
+
+  if (source.response_format != null || source.verbosity != null) {
+    result.text = {
+      ...(source.response_format != null
+        ? { format: convertResponseFormat(source.response_format) }
+        : {}),
+      ...(source.verbosity != null ? { verbosity: source.verbosity } : {}),
+    };
+  }
+  if (source.reasoning_effort != null) {
+    result.reasoning = { effort: source.reasoning_effort };
+  }
+  if (source.logprobs === true) {
+    result.include = ["message.output_text.logprobs"];
+  }
+  if (source.tools != null) result.tools = convertTools(source.tools);
+  if (source.tool_choice != null) {
+    result.tool_choice = convertToolChoice(source.tool_choice);
+  }
+
+  for (const key of [
+    "frequency_penalty",
+    "presence_penalty",
+    "seed",
+    "logit_bias",
+    "stop",
+  ] as const) {
+    if (source[key] != null) result[key] = source[key];
+  }
+
+  return result as ResponseRequest;
+}
+
+export function responseToChatCompletion(
+  response: OpenAIResponse,
+): ChatCompletion {
+  const textParts: string[] = [];
+  const refusals: string[] = [];
+  const toolCalls: ChatFunctionToolCall[] = [];
+
+  for (const item of response.output) {
+    switch (item.type) {
+      case "message":
+        for (const part of item.content) {
+          if (part.type === "output_text") textParts.push(part.text);
+          else if (part.type === "refusal") refusals.push(part.refusal);
+        }
+        break;
+      case "function_call":
+        if (!item.call_id) {
+          throw new Error(
+            "Responses function_call requires a non-empty call_id",
+          );
+        }
+        if (!item.name) {
+          throw new Error(
+            "Responses function_call requires a non-empty name",
+          );
+        }
+        toolCalls.push({
+          id: item.call_id,
+          type: "function",
+          function: { name: item.name, arguments: item.arguments },
+        });
+        break;
+      default:
+        break;
+    }
+  }
+
+  const message: ChatCompletion["choices"][number]["message"] = {
+    role: "assistant",
+    content: textParts.length > 0 ? textParts.join("") : null,
+    refusal: refusals.length > 0 ? refusals.join("") : null,
+    ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+  };
+
+  return {
+    id: response.id,
+    object: "chat.completion",
+    created: response.created_at,
+    model: response.model,
+    choices: [
+      {
+        index: 0,
+        message,
+        logprobs: null,
+        finish_reason: toolCalls.length > 0 ? "tool_calls" : "stop",
+      },
+    ],
+    usage: response.usage
+      ? {
+          prompt_tokens: response.usage.input_tokens,
+          completion_tokens: response.usage.output_tokens,
+          total_tokens: response.usage.total_tokens,
+          prompt_tokens_details: {
+            cached_tokens: response.usage.input_tokens_details.cached_tokens,
+          },
+          completion_tokens_details: {
+            reasoning_tokens:
+              response.usage.output_tokens_details.reasoning_tokens,
+          },
+        }
+      : undefined,
+    service_tier: response.service_tier,
+  };
+}

--- a/typescript/src/translation.ts
+++ b/typescript/src/translation.ts
@@ -21,6 +21,9 @@ type ChatFunctionToolCall = Extract<
   >[number],
   { type: "function" }
 >;
+type ChatChoiceLogprobs = NonNullable<
+  ChatCompletion["choices"][number]["logprobs"]
+>;
 
 /** Strip transport options and merge extra_body into the API payload. */
 export function cleanParams(
@@ -418,13 +421,29 @@ export function responseToChatCompletion(
   const textParts: string[] = [];
   const refusals: string[] = [];
   const toolCalls: ChatFunctionToolCall[] = [];
+  const contentLogprobs: NonNullable<ChatChoiceLogprobs["content"]> = [];
 
   for (const item of response.output) {
     switch (item.type) {
       case "message":
         for (const part of item.content) {
-          if (part.type === "output_text") textParts.push(part.text);
-          else if (part.type === "refusal") refusals.push(part.refusal);
+          if (part.type === "output_text") {
+            textParts.push(part.text);
+            for (const logprob of part.logprobs ?? []) {
+              contentLogprobs.push({
+                token: logprob.token,
+                bytes: logprob.bytes,
+                logprob: logprob.logprob,
+                top_logprobs: logprob.top_logprobs.map((top) => ({
+                  token: top.token,
+                  bytes: top.bytes,
+                  logprob: top.logprob,
+                })),
+              });
+            }
+          } else if (part.type === "refusal") {
+            refusals.push(part.refusal);
+          }
         }
         break;
       case "function_call":
@@ -465,7 +484,10 @@ export function responseToChatCompletion(
       {
         index: 0,
         message,
-        logprobs: null,
+        logprobs:
+          contentLogprobs.length > 0
+            ? { content: contentLogprobs, refusal: null }
+            : null,
         finish_reason: toolCalls.length > 0 ? "tool_calls" : "stop",
       },
     ],

--- a/typescript/test/client.test.ts
+++ b/typescript/test/client.test.ts
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Response } from "openai/resources/responses/responses";
+
+import {
+  AsyncOpenAI,
+  BatchOpenAI,
+  chatParamsToResponse,
+  responseToChatCompletion,
+} from "../src/client.ts";
+
+function makeResponse(
+  status: Response["status"] = "completed",
+  outputText = "hello",
+): Response {
+  return {
+    id: "resp-test",
+    object: "response",
+    created_at: 1_700_000_000,
+    completed_at: status === "completed" ? 1_700_000_001 : null,
+    status,
+    model: "test-model",
+    output_text: outputText,
+    output:
+      status === "completed"
+        ? [
+            {
+              id: "msg-test",
+              type: "message",
+              role: "assistant",
+              status: "completed",
+              content: [
+                {
+                  type: "output_text",
+                  text: outputText,
+                  annotations: [],
+                },
+              ],
+            },
+          ]
+        : [],
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    parallel_tool_calls: true,
+    temperature: null,
+    tool_choice: "auto",
+    tools: [],
+    top_p: null,
+    usage: {
+      input_tokens: 10,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens: 5,
+      output_tokens_details: { reasoning_tokens: 0 },
+      total_tokens: 15,
+    },
+  } as Response;
+}
+
+function makeClient(options: ConstructorParameters<typeof BatchOpenAI>[0] = {}) {
+  return new BatchOpenAI({
+    apiKey: "sk-test",
+    baseURL: "https://api.test/v1",
+    pollIntervalSeconds: 0,
+    ...options,
+  });
+}
+
+test("both public clients default text generation to flex", async () => {
+  const batch = makeClient();
+  const asyncClient = new AsyncOpenAI({
+    apiKey: "sk-test",
+    baseURL: "https://api.test/v1",
+  });
+  try {
+    assert.equal((batch as any)._completionWindow, undefined);
+    assert.equal((asyncClient as any)._completionWindow, undefined);
+  } finally {
+    await batch.close();
+    await asyncClient.close();
+  }
+});
+
+test("chat params translate to Responses API fields", () => {
+  assert.deepEqual(
+    chatParamsToResponse({
+      model: "test-model",
+      messages: [{ role: "user", content: "hello" }],
+      max_completion_tokens: 321,
+      response_format: { type: "json_object" },
+      temperature: 0.4,
+      stream: true,
+    }),
+    {
+      model: "test-model",
+      input: [{ role: "user", content: "hello" }],
+      max_output_tokens: 321,
+      text: { format: { type: "json_object" } },
+      temperature: 0.4,
+      stream: false,
+    },
+  );
+});
+
+test("chat params reject multiple choices", () => {
+  assert.throws(
+    () =>
+      chatParamsToResponse({
+        model: "test-model",
+        messages: [{ role: "user", content: "hello" }],
+        n: 2,
+      }),
+    /n=1/,
+  );
+});
+
+test("completed response converts to a chat completion", () => {
+  const completion = responseToChatCompletion(makeResponse());
+
+  assert.equal(completion.id, "resp-test");
+  assert.equal(completion.object, "chat.completion");
+  assert.equal(completion.choices[0]?.message.content, "hello");
+  assert.equal(completion.choices[0]?.finish_reason, "stop");
+  assert.equal(completion.usage?.prompt_tokens, 10);
+  assert.equal(completion.usage?.completion_tokens, 5);
+});
+
+test("function calls convert to chat tool calls", () => {
+  const response = makeResponse();
+  response.output = [
+    {
+      type: "function_call",
+      id: "fc-test",
+      call_id: "call-test",
+      name: "get_weather",
+      arguments: '{"city":"London"}',
+      status: "completed",
+    },
+  ];
+
+  const completion = responseToChatCompletion(response);
+
+  assert.equal(completion.choices[0]?.message.tool_calls?.[0]?.id, "call-test");
+  assert.equal(
+    completion.choices[0]?.message.tool_calls?.[0]?.function.name,
+    "get_weather",
+  );
+  assert.equal(completion.choices[0]?.finish_reason, "tool_calls");
+});
+
+test("flex responses submit in background and poll to completion", async () => {
+  const client = makeClient();
+  const createBodies: Array<Record<string, unknown>> = [];
+  const retrieveIDs: string[] = [];
+  const queued = makeResponse("queued", "");
+  const inProgress = makeResponse("in_progress", "");
+  const completed = makeResponse("completed", "done");
+  const results = [inProgress, completed];
+  (client as any)._responses = {
+    create: async (body: Record<string, unknown>) => {
+      createBodies.push(body);
+      return queued;
+    },
+    retrieve: async (id: string) => {
+      retrieveIDs.push(id);
+      return results.shift();
+    },
+  };
+
+  try {
+    const result = await (client as any)._executeFlex(
+      "/v1/responses",
+      { model: "test-model", input: "hello", stream: true },
+    );
+
+    assert.equal(result, completed);
+    assert.deepEqual(createBodies, [
+      {
+        model: "test-model",
+        input: "hello",
+        stream: false,
+        service_tier: "flex",
+        background: true,
+      },
+    ]);
+    assert.deepEqual(retrieveIDs, ["resp-test", "resp-test"]);
+  } finally {
+    await client.close();
+  }
+});
+
+for (const status of ["failed", "cancelled", "incomplete"] as const) {
+  test(`terminal ${status} flex response rejects`, async () => {
+    const client = makeClient();
+    const terminal = makeResponse(status);
+    (client as any)._responses = {
+      create: async () => terminal,
+      retrieve: async () => terminal,
+    };
+    try {
+      await assert.rejects(
+        (client as any)._executeFlex("/v1/responses", {
+          model: "test-model",
+          input: "hello",
+        }),
+        new RegExp(`resp-test.*${status}|${status}.*resp-test`),
+      );
+    } finally {
+      await client.close();
+    }
+  });
+}
+
+test("embeddings always route through a 24h batch", async () => {
+  const client = makeClient();
+  const calls: Array<[string, Record<string, unknown>]> = [];
+  (client as any)._enqueueBatch = async (
+    endpoint: string,
+    body: Record<string, unknown>,
+  ) => {
+    calls.push([endpoint, body]);
+    return { object: "list", data: [], model: "test", usage: {} };
+  };
+  (client as any)._executeFlex = async () => {
+    throw new Error("embeddings entered flex inference");
+  };
+
+  try {
+    await client._enqueue("/v1/embeddings", {
+      model: "embedding-model",
+      input: "hello",
+    });
+    assert.deepEqual(calls, [
+      ["/v1/embeddings", { model: "embedding-model", input: "hello" }],
+    ]);
+  } finally {
+    await client.close();
+  }
+});
+
+test("non-24h chat routes through flex without entering the batch queue", async () => {
+  const client = makeClient({ completionWindow: "1h" });
+  const calls: string[] = [];
+  (client as any)._executeFlex = async (endpoint: string) => {
+    calls.push(endpoint);
+    return { id: "chatcmpl-flex" };
+  };
+  (client as any)._enqueueBatch = async () => {
+    throw new Error("flex chat entered the batch queue");
+  };
+
+  try {
+    const result = await client._enqueue("/v1/chat/completions", {
+      model: "test-model",
+      messages: [{ role: "user", content: "hello" }],
+    });
+    assert.deepEqual(result, { id: "chatcmpl-flex" });
+    assert.deepEqual(calls, ["/v1/chat/completions"]);
+  } finally {
+    await client.close();
+  }
+});
+
+test("explicit 24h text routes through the batch path", async () => {
+  const client = makeClient({ completionWindow: "24h" });
+  const calls: string[] = [];
+  (client as any)._enqueueBatch = async (endpoint: string) => {
+    calls.push(endpoint);
+    return { id: "chatcmpl-batch" };
+  };
+  (client as any)._executeFlex = async () => {
+    throw new Error("24h text entered flex inference");
+  };
+
+  try {
+    await client._enqueue("/v1/chat/completions", {
+      model: "test-model",
+      messages: [{ role: "user", content: "hello" }],
+    });
+    assert.deepEqual(calls, ["/v1/chat/completions"]);
+  } finally {
+    await client.close();
+  }
+});

--- a/typescript/test/client.test.ts
+++ b/typescript/test/client.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { once } from "node:events";
 import { readFileSync } from "node:fs";
+import { request as httpRequest } from "node:http";
 import test from "node:test";
 
 import type { Response } from "openai/resources/responses/responses";
@@ -10,6 +12,7 @@ import {
   chatParamsToResponse,
   responseToChatCompletion,
 } from "../src/client.ts";
+import { serve } from "../src/serve.ts";
 
 interface TranslationCase {
   name: string;
@@ -82,6 +85,24 @@ function makeClient(options: ConstructorParameters<typeof BatchOpenAI>[0] = {}) 
   });
 }
 
+function captureRejectedBatchSubmissions(client: BatchOpenAI) {
+  const uploads: string[] = [];
+  const endpoints: string[] = [];
+  (client as any)._files = {
+    create: async ({ file }: { file: File }) => {
+      uploads.push(await file.text());
+      return { id: `file-${uploads.length}` };
+    },
+  };
+  (client as any)._batches = {
+    create: async ({ endpoint }: { endpoint: string }) => {
+      endpoints.push(endpoint);
+      throw new Error("stop after capturing batch submission");
+    },
+  };
+  return { uploads, endpoints };
+}
+
 test("both public clients default text generation to flex", async () => {
   const batch = makeClient();
   const asyncClient = new AsyncOpenAI({
@@ -94,6 +115,52 @@ test("both public clients default text generation to flex", async () => {
   } finally {
     await batch.close();
     await asyncClient.close();
+  }
+});
+
+test("non-create Responses methods remain delegated to the OpenAI resource", async () => {
+  const client = makeClient();
+  const expected = makeResponse();
+  const retrieved: string[] = [];
+  (client as any)._responses.retrieve = async (id: string) => {
+    retrieved.push(id);
+    return expected;
+  };
+
+  try {
+    const result = await client.responses.retrieve("resp-existing");
+    assert.equal(result, expected);
+    assert.deepEqual(retrieved, ["resp-existing"]);
+  } finally {
+    await client.close();
+  }
+});
+
+test("stored Chat Completion methods remain delegated", async () => {
+  const requested: string[] = [];
+  const client = makeClient({
+    fetch: async (url) => {
+      requested.push(String(url));
+      return new globalThis.Response(
+        JSON.stringify({
+          id: "chatcmpl-existing",
+          object: "chat.completion",
+          created: 1_700_000_000,
+          model: "test-model",
+          choices: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    },
+  });
+
+  try {
+    const result = await client.chat.completions.retrieve("chatcmpl-existing");
+    assert.equal(result.id, "chatcmpl-existing");
+    assert.equal(requested.length, 1);
+    assert.match(requested[0], /chat\/completions\/chatcmpl-existing/);
+  } finally {
+    await client.close();
   }
 });
 
@@ -224,6 +291,41 @@ test("refusal, service tier, and usage details survive chat adaptation", () => {
   assert.equal(completion.usage?.completion_tokens_details?.reasoning_tokens, 3);
 });
 
+test("output logprobs survive chat adaptation", () => {
+  const response = makeResponse();
+  const message = response.output[0];
+  assert.equal(message?.type, "message");
+  if (message?.type !== "message" || message.content[0]?.type !== "output_text") {
+    throw new Error("test response is not an output text message");
+  }
+  message.content[0].logprobs = [
+    {
+      token: "hello",
+      bytes: [104, 101, 108, 108, 111],
+      logprob: -0.25,
+      top_logprobs: [
+        { token: "hi", bytes: [104, 105], logprob: -1.5 },
+      ],
+    },
+  ];
+
+  const completion = responseToChatCompletion(response);
+
+  assert.deepEqual(completion.choices[0]?.logprobs, {
+    content: [
+      {
+        token: "hello",
+        bytes: [104, 101, 108, 108, 111],
+        logprob: -0.25,
+        top_logprobs: [
+          { token: "hi", bytes: [104, 105], logprob: -1.5 },
+        ],
+      },
+    ],
+    refusal: null,
+  });
+});
+
 test("function calls require a real call ID", () => {
   const response = makeResponse();
   response.output = [
@@ -276,6 +378,65 @@ test("flex responses submit in background and poll to completion", async () => {
       },
     ]);
     assert.deepEqual(retrieveIDs, ["resp-test", "resp-test"]);
+  } finally {
+    await client.close();
+  }
+});
+
+test("flex forwards per-request transport options to create and polls", async () => {
+  const client = makeClient();
+  const calls: Array<{ operation: string; options: unknown }> = [];
+  const queued = makeResponse("queued", "");
+  const completed = makeResponse("completed", "done");
+  (client as any)._responses = {
+    create: async (_body: unknown, options: unknown) => {
+      calls.push({ operation: "create", options });
+      return queued;
+    },
+    retrieve: async (_id: string, _query: unknown, options: unknown) => {
+      calls.push({ operation: "retrieve", options });
+      return completed;
+    },
+  };
+  const options = {
+    timeout: 12_500,
+    headers: { "X-Route": "tenant-a" },
+    query: { region: "uk" },
+  };
+
+  try {
+    await client.responses.create(
+      { model: "test-model", input: "hello" },
+      options,
+    );
+    assert.deepEqual(calls.map((call) => call.operation), [
+      "create",
+      "retrieve",
+    ]);
+    for (const call of calls) {
+      const forwarded = call.options as typeof options & { signal: AbortSignal };
+      assert.equal(forwarded.timeout, options.timeout);
+      assert.deepEqual(forwarded.headers, options.headers);
+      assert.deepEqual(forwarded.query, options.query);
+      assert.equal(forwarded.signal instanceof AbortSignal, true);
+    }
+  } finally {
+    await client.close();
+  }
+});
+
+test("24h batch mode rejects per-request transport options", async () => {
+  const client = makeClient({ completionWindow: "24h", batchSize: 1 });
+  captureRejectedBatchSubmissions(client);
+
+  try {
+    await assert.rejects(
+      client.responses.create(
+        { model: "test-model", input: "hello" },
+        { timeout: 100 },
+      ),
+      /transport options.*Batch|Batch.*transport/,
+    );
   } finally {
     await client.close();
   }
@@ -372,5 +533,144 @@ test("explicit 24h text routes through the batch path", async () => {
     assert.deepEqual(calls, ["/v1/chat/completions"]);
   } finally {
     await client.close();
+  }
+});
+
+test("24h queues submit separate batches for separate endpoints", async () => {
+  const client = makeClient({
+    completionWindow: "24h",
+    batchSize: 10,
+    batchWindowSeconds: 60,
+  });
+  const captured = captureRejectedBatchSubmissions(client);
+  const requests = Promise.allSettled([
+    client._enqueue("/v1/chat/completions", {
+      model: "test-model",
+      messages: [{ role: "user", content: "hello" }],
+    }),
+    client._enqueue("/v1/embeddings", {
+      model: "embedding-model",
+      input: "hello",
+    }),
+  ]);
+
+  await client.close();
+  await requests;
+
+  assert.deepEqual(captured.endpoints.sort(), [
+    "/v1/chat/completions",
+    "/v1/embeddings",
+  ]);
+  const uploadedEndpoints = captured.uploads
+    .flatMap((upload) => upload.split("\n"))
+    .map((line) => JSON.parse(line).url)
+    .sort();
+  assert.deepEqual(uploadedEndpoints, [
+    "/v1/chat/completions",
+    "/v1/embeddings",
+  ]);
+});
+
+test("24h text batches force non-streaming JSONL bodies", async () => {
+  const client = makeClient({
+    completionWindow: "24h",
+    batchSize: 10,
+    batchWindowSeconds: 60,
+  });
+  const captured = captureRejectedBatchSubmissions(client);
+  const request = client._enqueue("/v1/responses", {
+    model: "test-model",
+    input: "hello",
+    stream: true,
+    stream_options: { include_usage: true },
+  });
+
+  await client.close();
+  await Promise.allSettled([request]);
+
+  const line = JSON.parse(captured.uploads[0]);
+  assert.equal(line.body.stream, false);
+  assert.equal("stream_options" in line.body, false);
+});
+
+test("close aborts active flex polling and cancels the upstream response", async () => {
+  const client = makeClient({ pollIntervalSeconds: 0.01 });
+  const queued = makeResponse("queued", "");
+  const completed = makeResponse("completed", "done");
+  const cancelled: string[] = [];
+  let allowCompletion = false;
+  (client as any)._responses = {
+    create: async () => queued,
+    retrieve: async () => (allowCompletion ? completed : queued),
+    cancel: async (id: string) => {
+      cancelled.push(id);
+      return { ...queued, status: "cancelled" };
+    },
+  };
+
+  const request = client.responses
+    .create({ model: "test-model", input: "hello" })
+    .then(
+      () => "resolved",
+      () => "rejected",
+    );
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  try {
+    await client.close();
+    const outcome = await Promise.race([
+      request,
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve("still-polling"), 25),
+      ),
+    ]);
+
+    assert.equal(outcome, "rejected");
+    assert.deepEqual(cancelled, ["resp-test"]);
+  } finally {
+    allowCompletion = true;
+    await request;
+  }
+});
+
+test("HTTP proxy rejects oversized request bodies before parsing", async () => {
+  const { server, close } = serve({
+    apiKey: "sk-test",
+    baseURL: "https://api.test/v1",
+    host: "127.0.0.1",
+    port: 0,
+  });
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test server did not expose a TCP address");
+  }
+  const body = "x".repeat(1024 * 1024 + 1);
+
+  try {
+    const status = await new Promise<number | undefined>((resolve, reject) => {
+      const request = httpRequest(
+        {
+          host: "127.0.0.1",
+          port: address.port,
+          path: "/v1/responses",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Connection: "close",
+          },
+        },
+        (response) => {
+          response.resume();
+          response.on("end", () => resolve(response.statusCode));
+        },
+      );
+      request.on("error", reject);
+      request.end(body);
+    });
+
+    assert.equal(status, 413);
+  } finally {
+    await close();
   }
 });

--- a/typescript/test/client.test.ts
+++ b/typescript/test/client.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import type { Response } from "openai/resources/responses/responses";
@@ -9,6 +10,19 @@ import {
   chatParamsToResponse,
   responseToChatCompletion,
 } from "../src/client.ts";
+
+interface TranslationCase {
+  name: string;
+  chat_request: Record<string, unknown>;
+  response_request: Record<string, unknown>;
+}
+
+const translationCases = JSON.parse(
+  readFileSync(
+    new URL("../../fixtures/chat_responses_translation.json", import.meta.url),
+    "utf8",
+  ),
+) as TranslationCase[];
 
 function makeResponse(
   status: Response["status"] = "completed",
@@ -104,6 +118,15 @@ test("chat params translate to Responses API fields", () => {
   );
 });
 
+for (const translationCase of translationCases) {
+  test(`shared translation fixture: ${translationCase.name}`, () => {
+    assert.deepEqual(
+      chatParamsToResponse(translationCase.chat_request),
+      translationCase.response_request,
+    );
+  });
+}
+
 test("chat params reject multiple choices", () => {
   assert.throws(
     () =>
@@ -113,6 +136,23 @@ test("chat params reject multiple choices", () => {
         n: 2,
       }),
     /n=1/,
+  );
+});
+
+test("chat params reject custom tools outside the minimum SDK schema", () => {
+  assert.throws(
+    () =>
+      chatParamsToResponse({
+        model: "test-model",
+        messages: [{ role: "user", content: "hello" }],
+        tools: [
+          {
+            type: "custom",
+            custom: { name: "shell", format: { type: "text" } },
+          },
+        ],
+      }),
+    /custom.*tool|tool.*custom/,
   );
 });
 
@@ -148,6 +188,56 @@ test("function calls convert to chat tool calls", () => {
     "get_weather",
   );
   assert.equal(completion.choices[0]?.finish_reason, "tool_calls");
+});
+
+test("refusal, service tier, and usage details survive chat adaptation", () => {
+  const response = makeResponse();
+  response.service_tier = "priority";
+  response.output = [
+    {
+      id: "msg-refusal",
+      type: "message",
+      role: "assistant",
+      status: "completed",
+      content: [
+        { type: "refusal", refusal: "I cannot help with that." },
+      ],
+    },
+  ];
+  response.usage = {
+    input_tokens: 10,
+    input_tokens_details: { cached_tokens: 7 },
+    output_tokens: 5,
+    output_tokens_details: { reasoning_tokens: 3 },
+    total_tokens: 15,
+  };
+
+  const completion = responseToChatCompletion(response);
+
+  assert.equal(completion.choices[0]?.message.content, null);
+  assert.equal(
+    completion.choices[0]?.message.refusal,
+    "I cannot help with that.",
+  );
+  assert.equal(completion.service_tier, "priority");
+  assert.equal(completion.usage?.prompt_tokens_details?.cached_tokens, 7);
+  assert.equal(completion.usage?.completion_tokens_details?.reasoning_tokens, 3);
+});
+
+test("function calls require a real call ID", () => {
+  const response = makeResponse();
+  response.output = [
+    {
+      type: "function_call",
+      id: "fc-test",
+      call_id: "",
+      name: "get_weather",
+      arguments: "{}",
+      status: "completed",
+    },
+  ];
+
+  assert.throws(() => responseToChatCompletion(response), /call_id/);
 });
 
 test("flex responses submit in background and poll to completion", async () => {


### PR DESCRIPTION
## Summary

Default text calls now submit a background Responses request with the flex service tier and retrieve the result by response ID. This avoids creating an uploaded file and batch for each individual call. Chat Completions inputs and outputs are translated using official SDK types. Explicit 24-hour text requests and all embeddings retain the Batch API lifecycle.

Both SDKs limit simultaneous flex HTTP operations to 20 per client, releasing slots between polls. Polling uses jitter and bounded retries with exponential backoff for transient retrieval failures, without resubmitting accepted work. `FlexPollingError` exposes the accepted response ID and original error when polling stops. The concurrency limit and consecutive retry count are configurable with matching Python and TypeScript options.

Incomplete results preserve partial output and usage, with Chat finish reasons for token limits and content filtering. Cancellation preserves per-request credentials, routing options, and timeouts. Python streaming create accessors cannot bypass routing. The proxy rejects oversized uploads immediately, and chat translation preserves provider extension fields. Documentation explains polling, concurrency, and recovery behavior.

## Validation

- Python: 135 tests and `ty check` pass with the installed SDK and minimum supported OpenAI 2.0.0.
- TypeScript: 46 tests, typecheck, and build pass with the locked SDK and minimum supported OpenAI 4.104.0.
- Regression coverage includes retry recovery without resubmission, exhausted/permanent failures retaining IDs, retry-count reset, jitter/backoff and Retry-After, HTTP concurrency, cancelled waiters, partial output, and cancellation transport options.
- CI exercises both supported SDK configurations for each language.

The HTTP concurrency limit applies per client and does not cap queued server jobs or inherited resource calls. Database capacity has not been load-tested as part of this SDK change.
